### PR TITLE
Add combination mode selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,12 @@ A prompt enhancer that includes various modes with sticky negative support.
 The project is now purely JavaScript-based with a single web interface.
 
 ## Web Interface
-Open `index.html` in your browser to use the tool. It provides text areas for a base prompt list, a "bad" descriptor list, and a list of negative modifiers. You can choose default, empty, or custom lists using the drop-down menus next to each box. The page has a dark style loosely inspired by Diskrot.
+Open `index.html` in your browser to use the tool. It provides text areas for a base prompt list, a "bad" descriptor list, and a list of negative modifiers. You can choose default, empty, or custom lists using the drop-down menus next to each box. A separate selector allows you to choose the **combination mode** controlling how the negative and bad terms are mixed:
+
+* **Negative first** – run through negatives then bad descriptors (default).
+* **Bad first** – run through bad descriptors before negatives.
+* **Negative only** – output only negative-modified items.
+* **Bad only** – output only bad descriptors.
+* **Mixed** – randomly alternate between negatives and bad descriptors.
+
+The page has a dark style loosely inspired by Diskrot.

--- a/index.html
+++ b/index.html
@@ -31,6 +31,16 @@
     </select>
     <textarea id="neg-input" rows="2" placeholder="Custom negative modifiers" disabled></textarea>
   </div>
+  <div class="input-group">
+    <label for="mode-select">Combination Mode</label>
+    <select id="mode-select">
+      <option value="negative-first" selected>Negative first</option>
+      <option value="bad-first">Bad first</option>
+      <option value="negative-only">Negative only</option>
+      <option value="bad-only">Bad only</option>
+      <option value="mixed">Mixed</option>
+    </select>
+  </div>
   <button id="generate">Generate</button>
   <button id="randomize">Randomize</button>
   <div class="output">


### PR DESCRIPTION
## Summary
- implement combination mode logic
- support negative-only, bad-only, bad-first, negative-first, and mixed
- add combination mode dropdown to the HTML interface
- document new selector usage in README

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68441a1d93a88321898adfab837394d1