### PR TITLE
Add length limit selector and improve layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
             <option value="mixed">Mixed</option>
           </select>
         </div>
+        <div class="input-group">
+          <label for="length-select">Length Limit</label>
+          <select id="length-select">
+            <option value="1000" selected>Suno (1000)</option>
+            <option value="custom">Custom</option>
+          </select>
+          <input type="number" id="length-input" value="1000" min="1" disabled>
+        </div>
         <button id="generate">Generate</button>
         <button id="randomize">Randomize</button>
         <div class="output">

--- a/script.js
+++ b/script.js
@@ -95,10 +95,10 @@ function generatePositiveList(items, combinedNeg) {
   return pos;
 }
 
-function buildVersions(items, descs, negs, mode) {
+function buildVersions(items, descs, negs, mode, limit) {
   const negated = generateNegatedList(items, negs);
   const bad = generateBadDescriptorList(items, descs);
-  const combinedNeg = combineListsByMode(negated, bad, mode, 1000);
+  const combinedNeg = combineListsByMode(negated, bad, mode, limit);
   const positive = generatePositiveList(items, combinedNeg);
   return {
     good: positive.join(', '),
@@ -134,12 +134,32 @@ document.getElementById('neg-select').addEventListener('change', () => {
   getList(document.getElementById('neg-select'), document.getElementById('neg-input'), DEFAULT_NEGATIVE_MODIFIERS);
 });
 
+document.getElementById('length-select').addEventListener('change', () => {
+  const select = document.getElementById('length-select');
+  const input = document.getElementById('length-input');
+  if (select.value === 'custom') {
+    input.disabled = false;
+  } else {
+    input.value = select.value;
+    input.disabled = true;
+  }
+});
+
 function collectInputs() {
   const baseItems = parseInput(document.getElementById('base-input').value);
   const descs = getList(document.getElementById('desc-select'), document.getElementById('desc-input'), DEFAULT_DESCRIPTORS);
   const negs = getList(document.getElementById('neg-select'), document.getElementById('neg-input'), DEFAULT_NEGATIVE_MODIFIERS);
   const mode = document.getElementById('mode-select').value;
-  return { baseItems, descs, negs, mode };
+  const lengthSelect = document.getElementById('length-select');
+  const lengthInput = document.getElementById('length-input');
+  let limit;
+  if (lengthSelect.value === 'custom') {
+    limit = parseInt(lengthInput.value, 10) || 1000;
+  } else {
+    limit = parseInt(lengthSelect.value, 10);
+    lengthInput.value = limit;
+  }
+  return { baseItems, descs, negs, mode, limit };
 }
 
 function displayOutput(result) {
@@ -148,24 +168,24 @@ function displayOutput(result) {
 }
 
 function generate() {
-  const { baseItems, descs, negs, mode } = collectInputs();
+  const { baseItems, descs, negs, mode, limit } = collectInputs();
   if (!baseItems.length) {
     alert('Please enter at least one base prompt item.');
     return;
   }
-  const result = buildVersions(baseItems, descs, negs, mode);
+  const result = buildVersions(baseItems, descs, negs, mode, limit);
   displayOutput(result);
 }
 
 document.getElementById('generate').addEventListener('click', generate);
 
 document.getElementById('randomize').addEventListener('click', () => {
-  const { baseItems, descs, negs, mode } = collectInputs();
+  const { baseItems, descs, negs, mode, limit } = collectInputs();
   if (!baseItems.length) {
     alert('Please enter at least one base prompt item.');
     return;
   }
   const shuffled = baseItems.slice().sort(() => Math.random() - 0.5);
-  const result = buildVersions(shuffled, descs, negs, mode);
+  const result = buildVersions(shuffled, descs, negs, mode, limit);
   displayOutput(result);
 });

--- a/style.css
+++ b/style.css
@@ -11,7 +11,9 @@ body {
     flex-direction: column;
     min-height: 100vh;
     font-family: Arial, sans-serif;
-    background-color: black;
+    background: radial-gradient(circle at 20% 20%, rgba(102,0,0,0.7), transparent 60%),
+                radial-gradient(circle at 80% 80%, rgba(0,0,102,0.7), transparent 60%),
+                linear-gradient(135deg, #330000, #000033);
     color: white;
     overflow: hidden;
 }
@@ -50,6 +52,8 @@ body {
     height: 100vh;
     flex-direction: row;
     padding-top: 40px;
+    align-items: center;
+    justify-content: center;
 }
 
 .left {
@@ -85,7 +89,10 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 100px;
+    padding: 50px;
+    max-width: 600px;
+    width: 100%;
+    margin: auto;
     overflow-y: auto;
     text-align: center;
 }
@@ -271,11 +278,12 @@ blockquote p {
     }
 
     .right {
-        height: 50vh;
+        height: auto;
         width: 100%;
-        padding: 50px;
+        padding: 20px;
         justify-content: flex-start;
         overflow-y: scroll;
+        margin: 0;
     }
 
     .team img {
@@ -320,6 +328,15 @@ select {
     color: #fff;
     border: 1px solid #444;
     padding: 0.5rem;
+}
+
+input[type=number] {
+    width: 100%;
+    background: #222;
+    color: #fff;
+    border: 1px solid #444;
+    padding: 0.5rem;
+    margin-top: 0.5rem;
 }
 
 select {


### PR DESCRIPTION
## Summary
- add length limit selector with preset and custom options
- support user-configured limit in JS
- center layout and limit widths for better mobile/desktop behavior
- apply dark red to blue geometric gradient background

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68442602675483219ba270d51fc62049