### PR TITLE
Remove redundant modes; repeat lists to fill limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ Simply open `index.html` in your browser. No build step or server is required.
 3. Choose how the bad descriptors and negatives should be combined using the **Negative Combination Mode** menu:
    - *Negative first* (default)
    - *Bad first*
-   - *Negative only*
-   - *Bad only*
    - *Mixed*
 4. Toggle the **Positive Combination Mode** to turn positive modifiers on or off.
-5. Set the maximum length for the generated output (default 1000 characters).
+5. Set the maximum length for the generated output (default 1000 characters). The lists repeat as needed until this limit is reached.
 6. Click **Generate** to see the good and bad versions, or **Randomize** to shuffle the base list before generating.
 
 Built‑in descriptor lists live in `script.js` and can be extended by editing that file. The interface is styled by `style.css` and uses a dark theme inspired by Diskrot.

--- a/index.html
+++ b/index.html
@@ -51,8 +51,6 @@
           <select id="neg-mode-select">
             <option value="negative-first" selected>Negative first</option>
             <option value="bad-first">Bad first</option>
-            <option value="negative-only">Negative only</option>
-            <option value="bad-only">Bad only</option>
             <option value="mixed">Mixed</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- remove the "negative only" and "bad only" options from UI and docs
- clarify that generated lists repeat until reaching the length limit
- adjust generator logic so lists recycle until the output meets the chosen limit

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684444fb11d883219ad12010d1790abc