### PR TITLE
Refactor list handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,16 @@ Simply open `index.html` in your browser. No build step or server is required.
 
 1. Enter a comma, semicolon or newline separated **base prompt list**.
 2. For each list below the base prompt you can pick a **default**, **image** or **empty** set, or provide your own values:
-   - **Bad Descriptor List** – adjectives or phrases to prepend in the "bad" variant.
-   - **Negative Modifier List** – short negation words like `not` or `no`.
+   - **Bad Descriptor List** – adjectives or phrases to prepend in the "bad" variant. The "audio + negations" option mixes in words like `not` or `no`.
    - **Positive Modifier List** – words or phrases to prepend in the "good" variant.
 3. Choose how the bad descriptors and negatives should be combined using the **Negative Combination Mode** menu:
    - *Negative first* (default)
    - *Bad first*
    - *Mixed*
-4. Toggle the **Positive Combination Mode** to turn positive modifiers on or off.
-5. Set the maximum length for the generated output (default 1000 characters). The lists repeat as needed until this limit is reached.
-6. Click **Generate** to see the good and bad versions, or **Randomize** to shuffle the base list before generating.
+4. Set the maximum length for the generated output (default 1000 characters). The lists repeat as needed until this limit is reached.
+5. Click **Generate** to see the good and bad versions, or **Randomize** to shuffle the base list before generating.
 
-Built‑in descriptor lists live in `script.js` and can be extended by editing that file. The interface is styled by `style.css` and uses a dark theme inspired by Diskrot.
+Built‑in descriptor lists live in the `src/lists` folder and can be extended by editing those files. The interface is styled by `style.css` and uses a dark theme inspired by Diskrot.
 
 ## Repository Layout
 

--- a/src/index.html
+++ b/src/index.html
@@ -34,20 +34,12 @@
           <label for="desc-input">Bad Descriptor List</label>
           <select id="desc-select">
             <option value="default">Audio bad list</option>
+            <option value="audio-neg">Audio bad list + negations</option>
             <option value="image">Image bad list</option>
             <option value="empty" selected>Empty bad list</option>
             <option value="custom">Custom list</option>
           </select>
           <textarea id="desc-input" rows="3" placeholder="Custom descriptors" disabled></textarea>
-        </div>
-        <div class="input-group">
-          <label for="neg-input">Negative Modifier List</label>
-          <select id="neg-select">
-            <option value="default">Default no list</option>
-            <option value="empty" selected>Empty no list</option>
-            <option value="custom">Custom list</option>
-          </select>
-          <textarea id="neg-input" rows="2" placeholder="Custom negative modifiers" disabled></textarea>
         </div>
         <div class="input-group">
           <label for="pos-input">Positive Modifier List</label>
@@ -64,13 +56,6 @@
             <option value="negative-first" selected>Negative first</option>
             <option value="bad-first">Bad first</option>
             <option value="mixed">Mixed</option>
-          </select>
-        </div>
-        <div class="input-group">
-          <label for="pos-mode-select">Positive Combination Mode</label>
-          <select id="pos-mode-select">
-            <option value="on" selected>On</option>
-            <option value="off">Off</option>
           </select>
         </div>
         <div class="input-group">
@@ -101,7 +86,6 @@
   </script>
   <script src="lists/bad_lists.js"></script>
   <script src="lists/good_lists.js"></script>
-  <script src="lists/neg_modifier_lists.js"></script>
   <script src="script.js"></script>
 </body>
 

--- a/src/lists/bad_lists.js
+++ b/src/lists/bad_lists.js
@@ -58,6 +58,12 @@ const BAD_LISTS = {
   "Synthwave",
   "K-pop",
   ],
+  DEFAULT_NEGATIVE_MODIFIERS: [
+  "not",
+  "no",
+  "un-",
+  ],
+  DEFAULT_DESCRIPTORS_WITH_NEGATIONS: [],
   IMAGE_BAD_DESCRIPTORS: [
   "worst quality",
   "normal quality",
@@ -220,3 +226,6 @@ const BAD_LISTS = {
   "twisted",
   ]
 };
+
+BAD_LISTS.DEFAULT_DESCRIPTORS_WITH_NEGATIONS =
+  BAD_LISTS.DEFAULT_NEGATIVE_MODIFIERS.concat(BAD_LISTS.DEFAULT_DESCRIPTORS);

--- a/src/lists/neg_modifier_lists.js
+++ b/src/lists/neg_modifier_lists.js
@@ -1,7 +1,0 @@
-const NEGATIVE_MODIFIER_LISTS = {
-  DEFAULT_NEGATIVE_MODIFIERS: [
-  "not",
-  "no",
-  "un-",
-  ]
-};


### PR DESCRIPTION
## Summary
- move built-in lists into descriptor presets
- generalize list selection functions
- update docs to note lists live in `src/lists`

## Testing
- `node --check src/script.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68469509709483218376a33a3ac6dfb0