### PR TITLE
Improve list defaults and UI toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 3. **Select Modifier Lists**:
    - **Bad Descriptor List**: Choose a preset or create custom negative modifiers
    - **Positive Modifier List**: Choose a preset or create custom quality enhancers
-   - Toggle "Randomize order" to shuffle each list during generation
+   - Use the shuffle toggle next to each list title to randomize that list
 
 4. **Set Length Limit**:
    - Suno (1000 characters) - for Suno AI audio generation
@@ -44,7 +44,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 
 5. **Generate**:
    - Click "Generate" to create variations
-   - Use the shuffle toggle next to "Base Prompt List" to randomize base items when needed
+   - Shuffle toggles control whether each list is randomized
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The Prompt Enhancer helps you create more effective prompts by:
    - Custom - set your own limit
 
 5. **Generate**:
-   - Click "Generate" to create variations using the current order
-   - Click "Randomize" to shuffle the base prompt list before generation
+   - Click "Generate" to create variations
+   - Use the shuffle toggle next to "Base Prompt List" to randomize base items when needed
 
 ## How It Works
 

--- a/src/index.html
+++ b/src/index.html
@@ -33,30 +33,45 @@
         <h1>Prompt Enhancer</h1>
         <!-- Base prompt input section -->
         <div class="input-group">
-          <label for="base-input">Base Prompt List</label>
+          <div class="label-row">
+            <label for="base-input">Base Prompt List</label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="base-shuffle">
+              <span class="slider"></span>Random
+            </label>
+          </div>
           <textarea id="base-input" rows="4"
             placeholder="Enter comma, semicolon, or newline separated items"></textarea>
-          <label class="checkbox-label"><input type="checkbox" id="base-shuffle"> Randomize order</label>
         </div>
         <!-- Bad descriptor selection section -->
         <div class="input-group">
-          <label for="desc-input">Bad Descriptor List</label>
+          <div class="label-row">
+            <label for="desc-input">Bad Descriptor List</label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="desc-shuffle">
+              <span class="slider"></span>Random
+            </label>
+          </div>
           <select id="desc-select">
             <!-- Options will be populated dynamically from BAD_LISTS -->
             <option value="custom">Custom list</option>
           </select>
           <textarea id="desc-input" rows="3" placeholder="Custom descriptors" disabled></textarea>
-          <label class="checkbox-label"><input type="checkbox" id="desc-shuffle"> Randomize order</label>
         </div>
         <!-- Positive modifier selection section -->
         <div class="input-group">
-          <label for="pos-input">Positive Modifier List</label>
+          <div class="label-row">
+            <label for="pos-input">Positive Modifier List</label>
+            <label class="checkbox-label">
+              <input type="checkbox" id="pos-shuffle">
+              <span class="slider"></span>Random
+            </label>
+          </div>
           <select id="pos-select">
             <!-- Options will be populated dynamically from GOOD_LISTS -->
             <option value="custom">Custom list</option>
           </select>
           <textarea id="pos-input" rows="2" placeholder="Custom positive modifiers" disabled></textarea>
-          <label class="checkbox-label"><input type="checkbox" id="pos-shuffle"> Randomize order</label>
         </div>
         <!-- Character length limit selection -->
         <div class="input-group">
@@ -70,7 +85,6 @@
         </div>
         <!-- Action buttons -->
         <button id="generate">Generate</button>
-        <button id="randomize">Randomize</button>
         
         <!-- Output display section -->
         <div class="output">

--- a/src/index.html
+++ b/src/index.html
@@ -37,7 +37,8 @@
             <label for="base-input">Base Prompt List</label>
             <label class="checkbox-label">
               <input type="checkbox" id="base-shuffle">
-              <span class="slider"></span>Random
+              <span class="slider"></span>
+              <span class="toggle-text">Randomize</span>
             </label>
           </div>
           <textarea id="base-input" rows="4"
@@ -49,7 +50,8 @@
             <label for="desc-input">Bad Descriptor List</label>
             <label class="checkbox-label">
               <input type="checkbox" id="desc-shuffle">
-              <span class="slider"></span>Random
+              <span class="slider"></span>
+              <span class="toggle-text">Randomize</span>
             </label>
           </div>
           <select id="desc-select">
@@ -64,7 +66,8 @@
             <label for="pos-input">Positive Modifier List</label>
             <label class="checkbox-label">
               <input type="checkbox" id="pos-shuffle">
-              <span class="slider"></span>Random
+              <span class="slider"></span>
+              <span class="toggle-text">Randomize</span>
             </label>
           </div>
           <select id="pos-select">

--- a/src/lists/bad_lists.js
+++ b/src/lists/bad_lists.js
@@ -6,6 +6,11 @@ const BAD_LISTS = {
   // List of available presets with titles and data
   presets: [
     {
+      id: 'empty',
+      title: 'Empty bad list',
+      items: []
+    },
+    {
       id: 'audio-bad',
       title: 'Audio bad list',
       items: [
@@ -299,10 +304,5 @@ const BAD_LISTS = {
         "twisted",
       ]
     },
-    {
-      id: 'empty',
-      title: 'Empty bad list',
-      items: []
-    }
   ]
 };

--- a/src/lists/good_lists.js
+++ b/src/lists/good_lists.js
@@ -6,6 +6,11 @@ const GOOD_LISTS = {
   // List of available presets with titles and data
   presets: [
     {
+      id: 'empty',
+      title: 'Empty positive list',
+      items: []
+    },
+    {
       id: 'image-positive',
       title: 'Image positive list',
       items: [
@@ -75,10 +80,5 @@ const GOOD_LISTS = {
         "detailed skin texture",
       ]
     },
-    {
-      id: 'empty',
-      title: 'Empty positive list',
-      items: []
-    }
   ]
 };

--- a/src/script.js
+++ b/src/script.js
@@ -293,18 +293,6 @@ function generate() {
 // Attach generate function to button click
 document.getElementById('generate').addEventListener('click', generate);
 
-// Randomize button - forces shuffle of base items regardless of checkbox
-document.getElementById('randomize').addEventListener('click', () => {
-  const { baseItems, descs, posMods, shuffleBad, shufflePos, limit } = collectInputs();
-  if (!baseItems.length) {
-    alert('Please enter at least one base prompt item.');
-    return;
-  }
-  // Pre-shuffle the base items
-  const shuffled = baseItems.slice().sort(() => Math.random() - 0.5);
-  const result = buildVersions(shuffled, descs, posMods, true, shuffleBad, shufflePos, limit);
-  displayOutput(result);
-});
 
 /**
  * Initialize the UI with default selections
@@ -313,20 +301,6 @@ document.getElementById('randomize').addEventListener('click', () => {
 function initializeUI() {
   // Load lists and populate dropdowns
   loadLists();
-  
-  // Initialize descriptor list
-  const descSelect = document.getElementById('desc-select');
-  const descInput = document.getElementById('desc-input');
-  if (descSelect && descInput) {
-    getList(descSelect, descInput, DESC_PRESETS);
-  }
-  
-  // Initialize positive modifier list
-  const posSelect = document.getElementById('pos-select');
-  const posInput = document.getElementById('pos-input');
-  if (posSelect && posInput) {
-    getList(posSelect, posInput, POS_PRESETS);
-  }
 }
 
 // Initialize UI when DOM is ready

--- a/src/style.css
+++ b/src/style.css
@@ -369,7 +369,20 @@ button {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    position: relative;
+    padding-left: 1rem;
     margin-bottom: 0.25rem;
+}
+
+.label-row::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    background: #fff;
+    transform: translateY(-50%) rotate(45deg);
 }
 
 .checkbox-label {
@@ -384,34 +397,50 @@ button {
 }
 
 .checkbox-label .slider {
-    width: 34px;
-    height: 18px;
-    background: #444;
-    border-radius: 12px;
+    width: 36px;
+    height: 20px;
+    background: repeating-linear-gradient(
+        45deg,
+        #444,
+        #444 3px,
+        #333 3px,
+        #333 6px
+    );
+    border-radius: 6px;
     position: relative;
-    margin-right: 0.4rem;
+    margin-right: 0.25rem;
     transition: background 0.2s;
 }
 
 .checkbox-label .slider::before {
     content: '';
     position: absolute;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
+    width: 12px;
+    height: 12px;
     background: #fff;
-    top: 2px;
-    left: 2px;
+    top: 4px;
+    left: 4px;
+    transform: rotate(45deg) translateX(0);
     transition: transform 0.2s, background 0.2s;
 }
 
 .checkbox-label input[type=checkbox]:checked + .slider {
-    background: #fff;
+    background: repeating-linear-gradient(
+        45deg,
+        #fff,
+        #fff 3px,
+        #ddd 3px,
+        #ddd 6px
+    );
 }
 
 .checkbox-label input[type=checkbox]:checked + .slider::before {
-    transform: translateX(16px);
+    transform: rotate(45deg) translateX(16px);
     background: #000;
+}
+
+.toggle-text {
+    margin-left: 0.25rem;
 }
 
 /* ===== OUTPUT SECTION ===== */

--- a/src/style.css
+++ b/src/style.css
@@ -369,20 +369,7 @@ button {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    position: relative;
-    padding-left: 1rem;
     margin-bottom: 0.25rem;
-}
-
-.label-row::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 50%;
-    width: 8px;
-    height: 8px;
-    background: #fff;
-    transform: translateY(-50%) rotate(45deg);
 }
 
 .checkbox-label {
@@ -397,16 +384,10 @@ button {
 }
 
 .checkbox-label .slider {
-    width: 36px;
+    width: 40px;
     height: 20px;
-    background: repeating-linear-gradient(
-        45deg,
-        #444,
-        #444 3px,
-        #333 3px,
-        #333 6px
-    );
-    border-radius: 6px;
+    background: #555;
+    border-radius: 10px;
     position: relative;
     margin-right: 0.25rem;
     transition: background 0.2s;
@@ -415,32 +396,25 @@ button {
 .checkbox-label .slider::before {
     content: '';
     position: absolute;
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     background: #fff;
-    top: 4px;
-    left: 4px;
-    transform: rotate(45deg) translateX(0);
-    transition: transform 0.2s, background 0.2s;
+    top: 2px;
+    left: 2px;
+    border-radius: 50%;
+    transition: transform 0.2s;
 }
 
 .checkbox-label input[type=checkbox]:checked + .slider {
-    background: repeating-linear-gradient(
-        45deg,
-        #fff,
-        #fff 3px,
-        #ddd 3px,
-        #ddd 6px
-    );
+    background: #0d6efd;
 }
 
 .checkbox-label input[type=checkbox]:checked + .slider::before {
-    transform: rotate(45deg) translateX(16px);
-    background: #000;
+    transform: translateX(20px);
 }
 
 .toggle-text {
-    margin-left: 0.25rem;
+    margin-left: 0.5rem;
 }
 
 /* ===== OUTPUT SECTION ===== */

--- a/src/style.css
+++ b/src/style.css
@@ -365,15 +365,53 @@ button {
 }
 
 /* Checkbox label styling */
+.label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.25rem;
+}
+
 .checkbox-label {
     display: flex;
     align-items: center;
-    margin-top: 0.25rem;
+    cursor: pointer;
     font-size: 0.9rem;
 }
 
 .checkbox-label input[type=checkbox] {
-    margin-right: 0.5rem;
+    display: none;
+}
+
+.checkbox-label .slider {
+    width: 34px;
+    height: 18px;
+    background: #444;
+    border-radius: 12px;
+    position: relative;
+    margin-right: 0.4rem;
+    transition: background 0.2s;
+}
+
+.checkbox-label .slider::before {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #fff;
+    top: 2px;
+    left: 2px;
+    transition: transform 0.2s, background 0.2s;
+}
+
+.checkbox-label input[type=checkbox]:checked + .slider {
+    background: #fff;
+}
+
+.checkbox-label input[type=checkbox]:checked + .slider::before {
+    transform: translateX(16px);
+    background: #000;
 }
 
 /* ===== OUTPUT SECTION ===== */


### PR DESCRIPTION
## Summary
- default to empty good/bad lists and update list order
- style shuffle checkboxes as inline toggle switches
- move shuffle toggles beside labels to save space
- remove unused Randomize button
- simplify initialization logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846a9a5ba4c832180bb44a1459b0f26