### PR TITLE
Add output copy and hide toggles

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,8 @@
             <label for="base-input">Base Prompt List</label>
             <input type="checkbox" id="base-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="base-shuffle">Randomize</button>
+            <input type="checkbox" id="base-hide" data-targets="base-input" checked hidden>
+            <button type="button" class="toggle-button" data-target="base-hide">Hidden</button>
           </div>
           <textarea id="base-input" rows="4"
             placeholder="Enter comma, semicolon, or newline separated items"></textarea>
@@ -47,6 +49,8 @@
             <label for="desc-input">Bad Descriptor List</label>
             <input type="checkbox" id="desc-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="desc-shuffle">Randomize</button>
+            <input type="checkbox" id="desc-hide" data-targets="desc-select,desc-input" checked hidden>
+            <button type="button" class="toggle-button" data-target="desc-hide">Hidden</button>
           </div>
           <select id="desc-select">
             <!-- Options will be populated dynamically from BAD_LISTS -->
@@ -60,6 +64,8 @@
             <label for="pos-input">Positive Modifier List</label>
             <input type="checkbox" id="pos-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="pos-shuffle">Randomize</button>
+            <input type="checkbox" id="pos-hide" data-targets="pos-select,pos-input" checked hidden>
+            <button type="button" class="toggle-button" data-target="pos-hide">Hidden</button>
           </div>
           <select id="pos-select">
             <!-- Options will be populated dynamically from GOOD_LISTS -->
@@ -82,9 +88,17 @@
         
         <!-- Output display section -->
         <div class="output">
-          <h2>Good Version</h2>
+          <h2>Good Version
+            <input type="checkbox" id="good-hide" data-targets="good-output" checked hidden>
+            <button type="button" class="toggle-button" data-target="good-hide">Hidden</button>
+            <button type="button" class="copy-button" data-target="good-output">Copy</button>
+          </h2>
           <pre id="good-output"></pre>
-          <h2>Bad Version</h2>
+          <h2>Bad Version
+            <input type="checkbox" id="bad-hide" data-targets="bad-output" checked hidden>
+            <button type="button" class="toggle-button" data-target="bad-hide">Hidden</button>
+            <button type="button" class="copy-button" data-target="bad-output">Copy</button>
+          </h2>
           <pre id="bad-output"></pre>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
             <label for="desc-input">Bad Descriptor List</label>
             <input type="checkbox" id="desc-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="desc-shuffle">Randomize</button>
-            <input type="checkbox" id="desc-hide" data-targets="desc-select,desc-input" checked hidden>
+            <input type="checkbox" id="desc-hide" data-targets="desc-input" checked hidden>
             <button type="button" class="toggle-button" data-target="desc-hide">Hidden</button>
           </div>
           <select id="desc-select">
@@ -64,7 +64,7 @@
             <label for="pos-input">Positive Modifier List</label>
             <input type="checkbox" id="pos-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="pos-shuffle">Randomize</button>
-            <input type="checkbox" id="pos-hide" data-targets="pos-select,pos-input" checked hidden>
+            <input type="checkbox" id="pos-hide" data-targets="pos-input" checked hidden>
             <button type="button" class="toggle-button" data-target="pos-hide">Hidden</button>
           </div>
           <select id="pos-select">

--- a/src/index.html
+++ b/src/index.html
@@ -88,13 +88,13 @@
         
         <!-- Output display section -->
         <div class="output">
-          <h2>Good Version
+          <h2><span>Good Version</span>
             <input type="checkbox" id="good-hide" data-targets="good-output" checked hidden>
             <button type="button" class="toggle-button" data-target="good-hide">Hidden</button>
             <button type="button" class="copy-button" data-target="good-output">Copy</button>
           </h2>
           <pre id="good-output"></pre>
-          <h2>Bad Version
+          <h2><span>Bad Version</span>
             <input type="checkbox" id="bad-hide" data-targets="bad-output" checked hidden>
             <button type="button" class="toggle-button" data-target="bad-hide">Hidden</button>
             <button type="button" class="copy-button" data-target="bad-output">Copy</button>

--- a/src/script.js
+++ b/src/script.js
@@ -312,6 +312,7 @@ function initializeUI() {
     btn.addEventListener('click', () => {
       checkbox.checked = !checkbox.checked;
       btn.classList.toggle('active', checkbox.checked);
+      checkbox.dispatchEvent(new Event('change'));
     });
   });
 

--- a/src/script.js
+++ b/src/script.js
@@ -314,6 +314,35 @@ function initializeUI() {
       btn.classList.toggle('active', checkbox.checked);
     });
   });
+
+  // Set up hide toggles that show/hide target elements
+  document.querySelectorAll('input[type="checkbox"][data-targets]').forEach(cb => {
+    const ids = cb.dataset.targets.split(',').map(id => id.trim());
+    const elems = ids.map(id => document.getElementById(id)).filter(Boolean);
+    const update = () => {
+      elems.forEach(el => {
+        el.style.display = cb.checked ? 'none' : '';
+      });
+    };
+    cb.addEventListener('change', update);
+    update();
+  });
+
+  // Copy buttons
+  document.querySelectorAll('.copy-button').forEach(btn => {
+    const target = document.getElementById(btn.dataset.target);
+    if (!target) return;
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(target.textContent);
+        const orig = btn.textContent;
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = orig; }, 1000);
+      } catch (err) {
+        console.error('Copy failed', err);
+      }
+    });
+  });
 }
 
 // Initialize UI when DOM is ready

--- a/src/style.css
+++ b/src/style.css
@@ -389,6 +389,21 @@ button {
     border-color: transparent;
 }
 
+/* Copy button styling */
+.copy-button {
+    background: transparent;
+    border: 1px solid #888;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-left: 0.25rem;
+}
+
+.copy-button:hover {
+    background: #444;
+}
+
 /* ===== OUTPUT SECTION ===== */
 .output pre {
     background: #222;

--- a/src/style.css
+++ b/src/style.css
@@ -115,7 +115,7 @@ body {
     padding: 20px;
     width: 100%;
     max-width: 800px;
-    text-align: center;
+    text-align: left; /* left align everything by default */
 }
 
 /* Middle Finger section - monospace font styling */
@@ -364,12 +364,20 @@ button {
     cursor: pointer;
 }
 
+#generate {
+    display: block;
+    margin: 1rem auto; /* center the generate button */
+}
+
 /* Checkbox label styling */
 .label-row {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     margin-bottom: 0.25rem;
+}
+
+.label-row label {
+    margin-right: auto; /* push button stack to the right */
 }
 
 
@@ -405,6 +413,21 @@ button {
 }
 
 /* ===== OUTPUT SECTION ===== */
+.output h2 {
+    display: flex;
+    align-items: center;
+    text-align: left;
+}
+
+.output h2 span {
+    margin-right: auto;
+}
+
+.output h2 .toggle-button,
+.output h2 .copy-button {
+    margin-left: 0.25rem;
+}
+
 .output pre {
     background: #222;
     padding: 0.5rem;


### PR DESCRIPTION
## Summary
- add `Hidden` toggle to base, bad, and positive lists so text areas start hidden
- add `Hidden` toggle and Copy buttons for good and bad outputs
- implement JS to handle hide toggles and copy buttons
- style copy buttons

## Testing
- `node --check src/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6846b8d75f54832182eb535111561dc1