### PR TITLE
Improve output styling and add master hide toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,7 +35,7 @@
         <div class="input-group">
           <div class="label-row">
             <label>Visibility</label>
-            <input type="checkbox" id="all-hide" hidden>
+            <input type="checkbox" id="all-hide" checked hidden>
             <button type="button" class="toggle-button" data-target="all-hide">Hide All</button>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,14 @@
       <!-- Tool content section -->
       <div id="tool" class="content">
         <h1>Prompt Enhancer</h1>
+        <!-- Hide all toggle -->
+        <div class="input-group">
+          <div class="label-row">
+            <label>Visibility</label>
+            <input type="checkbox" id="all-hide" hidden>
+            <button type="button" class="toggle-button" data-target="all-hide">Hide All</button>
+          </div>
+        </div>
         <!-- Base prompt input section -->
         <div class="input-group">
           <div class="label-row">

--- a/src/script.js
+++ b/src/script.js
@@ -308,7 +308,8 @@ function initializeUI() {
   });
 
   // Set up hide toggles that show/hide target elements
-  document.querySelectorAll('input[type="checkbox"][data-targets]').forEach(cb => {
+  const hideCheckboxes = Array.from(document.querySelectorAll('input[type="checkbox"][data-targets]'));
+  hideCheckboxes.forEach(cb => {
     const ids = cb.dataset.targets.split(',').map(id => id.trim());
     const elems = ids.map(id => document.getElementById(id)).filter(Boolean);
     const update = () => {
@@ -319,6 +320,19 @@ function initializeUI() {
     cb.addEventListener('change', update);
     update();
   });
+
+  // Master hide toggle
+  const allHide = document.getElementById('all-hide');
+  if (allHide) {
+    allHide.addEventListener('change', () => {
+      hideCheckboxes.forEach(cb => {
+        cb.checked = allHide.checked;
+        const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
+        if (btn) btn.classList.toggle('active', cb.checked);
+        cb.dispatchEvent(new Event('change'));
+      });
+    });
+  }
 
   // Copy buttons
   document.querySelectorAll('.copy-button').forEach(btn => {

--- a/src/style.css
+++ b/src/style.css
@@ -417,6 +417,8 @@ button {
     display: flex;
     align-items: center;
     text-align: left;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
 }
 
 .output h2 span {
@@ -433,4 +435,6 @@ button {
     padding: 0.5rem;
     border: 1px solid #444;
     white-space: pre-wrap; /* Wrap long lines */
+    font-family: inherit;
+    margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- add a "Hide All" toggle for controlling all visibility options at once
- match output font with rest of page and add spacing between good and bad outputs
- update script to support master hide checkbox

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1df4a9c83218513d2150da96709