### PR TITLE
Fix editable length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 4. **Set Length Limit**:
    - Suno (1000 characters) - for Suno AI audio generation
    - Riffusion (10000 characters) - for Riffusion
-   - Custom - set your own limit
+   - Edit the value directly to set your own limit
 
 5. **Generate**:
    - Click "Generate" to create variations

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The Prompt Enhancer helps you create more effective prompts by:
    - Use the shuffle toggle next to each list title to randomize that list
 
 4. **Set Length Limit**:
-   - Suno (1000 characters) - for Suno AI audio generation
-   - Riffusion (10000 characters) - for Riffusion
-   - Edit the value directly to set your own limit
+   - Choose a preset such as Suno (1000) or Riffusion (10000)
+   - The number field remains editable for custom values
+   - Use the **Hidden** toggle to hide this section if desired
 
 5. **Generate**:
    - Click "Generate" to create variations
@@ -78,8 +78,9 @@ src/
 ├── assets/
 │   └── logo.png        # Diskrot logo
 └── lists/
-    ├── bad_lists.js    # Negative descriptor presets
-    └── good_lists.js   # Positive modifier presets
+    ├── bad_lists.js     # Negative descriptor presets
+    ├── good_lists.js    # Positive modifier presets
+    └── length_lists.js  # Length limit presets
 ```
 
 ### Key Files
@@ -108,6 +109,8 @@ const BAD_LISTS = {
   ]
 };
 ```
+
+Length presets follow the same structure in `length_lists.js` with a single value per list.
 
 The system will automatically detect and add new presets to the dropdown menus.
 

--- a/src/index.html
+++ b/src/index.html
@@ -83,12 +83,11 @@
         <div class="input-group">
           <div class="label-row">
             <label for="length-input">Length Limit</label>
-            <input type="checkbox" id="length-hide" data-targets="length-select,length-input" checked hidden>
+            <input type="checkbox" id="length-hide" data-targets="length-input" checked hidden>
             <button type="button" class="toggle-button" data-target="length-hide">Hidden</button>
           </div>
           <select id="length-select">
-            <option value="1000" selected>Suno (1000)</option>
-            <option value="10000">Riffusion (10000)</option>
+            <!-- Options will be populated dynamically from LENGTH_LISTS -->
           </select>
           <input type="number" id="length-input" value="1000" min="1">
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -125,6 +125,7 @@
   <!-- Load list data files first -->
   <script src="lists/bad_lists.js"></script>
   <script src="lists/good_lists.js"></script>
+  <script src="lists/length_lists.js"></script>
   <!-- Then load main application logic -->
   <script src="script.js"></script>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -81,13 +81,16 @@
         </div>
         <!-- Character length limit selection -->
         <div class="input-group">
-          <label for="length-select">Length Limit</label>
+          <div class="label-row">
+            <label for="length-input">Length Limit</label>
+            <input type="checkbox" id="length-hide" data-targets="length-select,length-input" checked hidden>
+            <button type="button" class="toggle-button" data-target="length-hide">Hidden</button>
+          </div>
           <select id="length-select">
             <option value="1000" selected>Suno (1000)</option>
             <option value="10000">Riffusion (10000)</option>
-            <option value="custom">Custom</option>
           </select>
-          <input type="number" id="length-input" value="1000" min="1" disabled>
+          <input type="number" id="length-input" value="1000" min="1">
         </div>
         <!-- Action buttons -->
         <button id="generate">Generate</button>

--- a/src/lists/length_lists.js
+++ b/src/lists/length_lists.js
@@ -1,0 +1,18 @@
+/**
+ * Character length limit presets
+ * Each preset contains a title and a single numeric value as an item
+ */
+const LENGTH_LISTS = {
+  presets: [
+    {
+      id: 'suno',
+      title: 'Suno (1000)',
+      items: ['1000']
+    },
+    {
+      id: 'riffusion',
+      title: 'Riffusion (10000)',
+      items: ['10000']
+    }
+  ]
+};

--- a/src/script.js
+++ b/src/script.js
@@ -220,12 +220,7 @@ document.getElementById('pos-select').addEventListener('change', () => {
 document.getElementById('length-select').addEventListener('change', () => {
   const select = document.getElementById('length-select');
   const input = document.getElementById('length-input');
-  if (select.value === 'custom') {
-    input.disabled = false;
-  } else {
-    input.value = select.value;
-    input.disabled = true;
-  }
+  input.value = select.value;
 });
 
 /**
@@ -241,13 +236,11 @@ function collectInputs() {
   const shufflePos = document.getElementById('pos-shuffle').checked;
   const lengthSelect = document.getElementById('length-select');
   const lengthInput = document.getElementById('length-input');
-  
+
   // Determine character limit
-  let limit;
-  if (lengthSelect.value === 'custom') {
-    limit = parseInt(lengthInput.value, 10) || 1000;
-  } else {
-    limit = parseInt(lengthSelect.value, 10);
+  let limit = parseInt(lengthInput.value, 10);
+  if (isNaN(limit) || limit <= 0) {
+    limit = parseInt(lengthSelect.value, 10) || 1000;
     lengthInput.value = limit;
   }
   

--- a/src/script.js
+++ b/src/script.js
@@ -13,6 +13,7 @@
 // Global preset storage for descriptor and positive modifier lists
 let DESC_PRESETS = {};
 let POS_PRESETS = {};
+let LENGTH_PRESETS = {};
 
 /**
  * Populates a select element with options from preset data
@@ -72,9 +73,23 @@ function loadLists() {
     }
   }
 
+  // Process length limit presets
+  if (typeof LENGTH_LISTS === 'object' && LENGTH_LISTS.presets) {
+    LENGTH_PRESETS = {};
+    LENGTH_LISTS.presets.forEach(preset => {
+      LENGTH_PRESETS[preset.id] = preset.items || [];
+    });
+
+    const lengthSelect = document.getElementById('length-select');
+    if (lengthSelect) {
+      populateSelect(lengthSelect, LENGTH_LISTS.presets);
+    }
+  }
+
   console.log('Lists loaded:', {
     descPresets: Object.keys(DESC_PRESETS).length,
-    posPresets: Object.keys(POS_PRESETS).length
+    posPresets: Object.keys(POS_PRESETS).length,
+    lengthPresets: Object.keys(LENGTH_PRESETS).length
   });
 }
 
@@ -197,11 +212,15 @@ function buildVersions(items, descs, posMods, shuffleBase, shuffleBad, shufflePo
  * @param {HTMLTextAreaElement} textareaEl - Associated textarea
  * @param {Object} presets - Preset lists object
  */
-function applyPreset(selectEl, textareaEl, presets) {
+function applyPreset(selectEl, inputEl, presets) {
   const key = selectEl.value;
   const list = presets[key] || [];
-  textareaEl.value = list.join(', ');
-  textareaEl.disabled = false;
+  if (inputEl.tagName === 'TEXTAREA') {
+    inputEl.value = list.join(', ');
+  } else {
+    inputEl.value = list[0] || '';
+  }
+  inputEl.disabled = false;
 }
 
 // Event listener for bad descriptor dropdown changes
@@ -218,9 +237,11 @@ document.getElementById('pos-select').addEventListener('change', () => {
 
 // Event listener for length limit dropdown changes
 document.getElementById('length-select').addEventListener('change', () => {
-  const select = document.getElementById('length-select');
-  const input = document.getElementById('length-input');
-  input.value = select.value;
+  applyPreset(
+    document.getElementById('length-select'),
+    document.getElementById('length-input'),
+    LENGTH_PRESETS
+  );
 });
 
 /**
@@ -285,6 +306,7 @@ function initializeUI() {
   // Populate textareas with initially selected presets
   applyPreset(document.getElementById('desc-select'), document.getElementById('desc-input'), DESC_PRESETS);
   applyPreset(document.getElementById('pos-select'), document.getElementById('pos-input'), POS_PRESETS);
+  applyPreset(document.getElementById('length-select'), document.getElementById('length-input'), LENGTH_PRESETS);
 
   // Set up toggle buttons linked to hidden checkboxes
   document.querySelectorAll('.toggle-button').forEach(btn => {

--- a/src/script.js
+++ b/src/script.js
@@ -261,7 +261,8 @@ function collectInputs() {
   // Determine character limit
   let limit = parseInt(lengthInput.value, 10);
   if (isNaN(limit) || limit <= 0) {
-    limit = parseInt(lengthSelect.value, 10) || 1000;
+    const preset = LENGTH_PRESETS[lengthSelect.value];
+    limit = preset ? parseInt(preset[0], 10) : 1000;
     lengthInput.value = limit;
   }
   


### PR DESCRIPTION
## Summary
- remove deprecated custom option
- allow length input to always be edited
- add hidden toggle for length fields
- update README instructions

## Testing
- `node --check src/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6846c4686ee48321bbdc41497ccbcd01