### PR TITLE
Fix button width on mobile

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -296,7 +296,7 @@ blockquote p {
     }
 
     button {
-        width: 100%;
+        width: auto; /* keep buttons at their natural size */
         margin-bottom: 0.5rem;
         margin-right: 0;
     }


### PR DESCRIPTION
## Summary
- prevent mobile buttons from expanding to full width

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68493c254eb48321aa56e5b0fd74e22e