### PR TITLE
Normalize negative modifier naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A lightweight web utility for creating enhanced prompt variations for AI models.
 ## Overview
 
 The Prompt Enhancer helps you create more effective prompts by:
-- **Positive Conditioning**: Adds positive descriptors to enhance output quality
-- **Negative Conditioning**: Prepends negative descriptors to help AI models avoid unwanted characteristics
+- **Positive Conditioning**: Adds positive modifiers to enhance output quality
+- **Negative Conditioning**: Prepends negative modifiers to help AI models avoid unwanted characteristics
 - **Cycling Algorithm**: Intelligently cycles through modifiers to maximize prompt diversity within character limits
 
 ## Features
@@ -33,8 +33,8 @@ The Prompt Enhancer helps you create more effective prompts by:
    - Example: `cyberpunk city, neon lights, rain`
 
 3. **Select Modifier Lists**:
-   - **Negative Descriptor List**: Choose a preset or create custom negative descriptors
-   - **Positive Descriptor List**: Choose a preset or create custom positive descriptors
+   - **Negative Modifier List**: Choose a preset or create custom negative modifiers
+   - **Positive Modifier List**: Choose a preset or create custom positive modifiers
    - Use the shuffle toggle next to each list title to randomize that list
 
 4. **Set Length Limit**:
@@ -60,9 +60,9 @@ The tool uses a cycling algorithm that:
 
 **Input Base Prompts**: `jazz, blues, rock`
 
-**Negative Descriptors**: `mediocre, amateur`
+**Negative Modifiers**: `mediocre, amateur`
 
-**Positive Descriptors**: `masterpiece, high quality`
+**Positive Modifiers**: `masterpiece, high quality`
 
 **Output**:
 - Negative Conditioning: `mediocre jazz, amateur blues, mediocre rock, amateur jazz...`
@@ -78,8 +78,8 @@ src/
 ├── assets/
 │   └── logo.png        # Diskrot logo
 └── lists/
-    ├── bad_lists.js     # Negative descriptor presets
-    ├── good_lists.js    # Positive descriptor presets
+    ├── bad_lists.js     # Negative modifier presets
+    ├── good_lists.js    # Positive modifier presets
     └── length_lists.js  # Length limit presets
 ```
 

--- a/src/index.html
+++ b/src/index.html
@@ -51,10 +51,10 @@
           <textarea id="base-input" rows="4"
             placeholder="Enter comma, semicolon, or newline separated items"></textarea>
         </div>
-        <!-- Negative descriptor selection section -->
+        <!-- Negative modifier selection section -->
         <div class="input-group">
           <div class="label-row">
-            <label for="neg-input">Negative Descriptor List</label>
+            <label for="neg-input">Negative Modifier List</label>
             <input type="checkbox" id="neg-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="neg-shuffle">Randomize</button>
             <input type="checkbox" id="neg-hide" data-targets="neg-input" checked hidden>
@@ -63,12 +63,12 @@
           <select id="neg-select">
             <!-- Options will be populated dynamically from NEGATIVE_LISTS -->
           </select>
-          <textarea id="neg-input" rows="3" placeholder="Negative descriptors"></textarea>
+          <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
         </div>
-        <!-- Positive descriptor selection section -->
+        <!-- Positive modifier selection section -->
         <div class="input-group">
           <div class="label-row">
-            <label for="pos-input">Positive Descriptor List</label>
+            <label for="pos-input">Positive Modifier List</label>
             <input type="checkbox" id="pos-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="pos-shuffle">Randomize</button>
             <input type="checkbox" id="pos-hide" data-targets="pos-input" checked hidden>
@@ -77,7 +77,7 @@
           <select id="pos-select">
             <!-- Options will be populated dynamically from POSITIVE_LISTS -->
           </select>
-          <textarea id="pos-input" rows="2" placeholder="Positive descriptors"></textarea>
+          <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
         </div>
         <!-- Character length limit selection -->
         <div class="input-group">

--- a/src/lists/bad_lists.js
+++ b/src/lists/bad_lists.js
@@ -1,5 +1,5 @@
 /**
- * Negative descriptor lists for prompt generation
+ * Negative modifier lists for prompt generation
  * Each list includes a title and the actual list items
  */
 const NEGATIVE_LISTS = {

--- a/src/lists/good_lists.js
+++ b/src/lists/good_lists.js
@@ -1,5 +1,5 @@
 /**
- * Positive descriptor lists for prompt generation
+ * Positive modifier lists for prompt generation
  * Each list includes a title and the actual list items
  */
 const POSITIVE_LISTS = {

--- a/src/script.js
+++ b/src/script.js
@@ -10,7 +10,7 @@
  * - Other AI models that benefit from negative prompting
  */
 
-// Global preset storage for negative and positive descriptor lists
+// Global preset storage for negative and positive modifier lists
 let NEG_PRESETS = {};
 let POS_PRESETS = {};
 let LENGTH_PRESETS = {};
@@ -43,7 +43,7 @@ function populateSelect(selectEl, presets) {
  * Dynamically structures the data based on available lists
  */
 function loadLists() {
-  // Process negative descriptor presets
+  // Process negative modifier presets
   if (typeof NEGATIVE_LISTS === 'object' && NEGATIVE_LISTS.presets) {
     // Convert presets array to object for easier access
     NEG_PRESETS = {};
@@ -51,10 +51,10 @@ function loadLists() {
       NEG_PRESETS[preset.id] = preset.items || [];
     });
     
-    // Populate the negative descriptor dropdown
-    const descSelect = document.getElementById('neg-select');
-    if (descSelect) {
-      populateSelect(descSelect, NEGATIVE_LISTS.presets);
+    // Populate the negative modifier dropdown
+    const negSelect = document.getElementById('neg-select');
+    if (negSelect) {
+      populateSelect(negSelect, NEGATIVE_LISTS.presets);
     }
   }
   
@@ -87,7 +87,7 @@ function loadLists() {
   }
 
   console.log('Lists loaded:', {
-    descPresets: Object.keys(NEG_PRESETS).length,
+    negPresets: Object.keys(NEG_PRESETS).length,
     posPresets: Object.keys(POS_PRESETS).length,
     lengthPresets: Object.keys(LENGTH_PRESETS).length
   });
@@ -173,22 +173,22 @@ function buildPrefixedList(orderedItems, prefixes, limit, shuffleItems = false, 
  * until the character limit is reached.
  *
  * @param {string[]} items - Base prompt items to enhance
- * @param {string[]} negDescs - Negative descriptors for the negative version
- * @param {string[]} posMods - Positive descriptors for the positive version
+ * @param {string[]} negMods - Negative modifiers for the negative version
+ * @param {string[]} posMods - Positive modifiers for the positive version
  * @param {boolean} shuffleBase - Whether to randomize base items
- * @param {boolean} shuffleNeg - Whether to randomize negative descriptors
+ * @param {boolean} shuffleNeg - Whether to randomize negative modifiers
  * @param {boolean} shufflePos - Whether to randomize positive modifiers
  * @param {number} limit - Character limit for output
  * @returns {{positive: string, negative: string}} Object with positive and negative prompt strings
 */
-function buildVersions(items, negDescs, posMods, shuffleBase, shuffleNeg, shufflePos, limit) {
+function buildVersions(items, negMods, posMods, shuffleBase, shuffleNeg, shufflePos, limit) {
   if (!items.length) {
     return { positive: '', negative: '' };
   }
 
   if (shuffleBase) shuffle(items);
 
-  const negTerms = buildPrefixedList(items, negDescs, limit, false, shuffleNeg);
+  const negTerms = buildPrefixedList(items, negMods, limit, false, shuffleNeg);
   const posTerms = buildPrefixedList(items, posMods, limit, false, shufflePos);
 
   const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
@@ -217,7 +217,7 @@ function applyPreset(selectEl, inputEl, presets) {
   inputEl.disabled = false;
 }
 
-// Event listener for negative descriptor dropdown changes
+// Event listener for negative modifier dropdown changes
 document.getElementById('neg-select').addEventListener('change', () => {
   console.log('Neg select changed to:', document.getElementById('neg-select').value);
   applyPreset(document.getElementById('neg-select'), document.getElementById('neg-input'), NEG_PRESETS);
@@ -244,7 +244,7 @@ document.getElementById('length-select').addEventListener('change', () => {
  */
 function collectInputs() {
   const baseItems = parseInput(document.getElementById('base-input').value);
-  const negDescs = parseInput(document.getElementById('neg-input').value);
+  const negMods = parseInput(document.getElementById('neg-input').value);
   const posMods = parseInput(document.getElementById('pos-input').value);
   const shuffleBase = document.getElementById('base-shuffle').checked;
   const shuffleNeg = document.getElementById('neg-shuffle').checked;
@@ -260,7 +260,7 @@ function collectInputs() {
     lengthInput.value = limit;
   }
   
-  return { baseItems, negDescs, posMods, shuffleBase, shuffleNeg, shufflePos, limit };
+  return { baseItems, negMods, posMods, shuffleBase, shuffleNeg, shufflePos, limit };
 }
 
 /**
@@ -277,12 +277,12 @@ function displayOutput(result) {
  * Validates input and generates both versions
  */
 function generate() {
-  const { baseItems, negDescs, posMods, shuffleBase, shuffleNeg, shufflePos, limit } = collectInputs();
+  const { baseItems, negMods, posMods, shuffleBase, shuffleNeg, shufflePos, limit } = collectInputs();
   if (!baseItems.length) {
     alert('Please enter at least one base prompt item.');
     return;
   }
-  const result = buildVersions(baseItems, negDescs, posMods, shuffleBase, shuffleNeg, shufflePos, limit);
+  const result = buildVersions(baseItems, negMods, posMods, shuffleBase, shuffleNeg, shufflePos, limit);
   displayOutput(result);
 }
 


### PR DESCRIPTION
## Summary
- rename `negDescs` to `negMods` and related variables
- update UI labels to use "modifier" for negative lists
- adjust docs to replace "descriptor" with "modifier"
- clarify comments in modifier list files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68495986ab288321b48612b1dd83f04d