### PR TITLE
Add randomize all and negative include option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,6 +35,8 @@
         <div class="input-group">
           <div class="label-row">
             <label>Visibility</label>
+            <input type="checkbox" id="all-random" hidden>
+            <button type="button" class="toggle-button" data-target="all-random">Randomize All</button>
             <input type="checkbox" id="all-hide" checked hidden>
             <button type="button" class="toggle-button" data-target="all-hide">Hide All</button>
           </div>
@@ -45,7 +47,7 @@
             <label for="base-input">Base Prompt List</label>
             <input type="checkbox" id="base-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="base-shuffle">Randomize</button>
-            <input type="checkbox" id="base-hide" data-targets="base-input" checked hidden>
+            <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
             <button type="button" class="toggle-button" data-target="base-hide">Hidden</button>
           </div>
           <textarea id="base-input" rows="4"
@@ -57,6 +59,8 @@
             <label for="neg-input">Negative Modifier List</label>
             <input type="checkbox" id="neg-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="neg-shuffle">Randomize</button>
+            <input type="checkbox" id="neg-include-pos" hidden>
+            <button type="button" class="toggle-button" data-target="neg-include-pos">Include Positive Mods</button>
             <input type="checkbox" id="neg-hide" data-targets="neg-input" checked hidden>
             <button type="button" class="toggle-button" data-target="neg-hide">Hidden</button>
           </div>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -35,4 +35,9 @@ describe('Prompt building', () => {
     const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20);
     expect(out).toEqual({ positive: 'good cat, good cat', negative: 'bad cat, bad cat' });
   });
+
+  test('buildVersions can include positive terms for negatives', () => {
+    const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20, true);
+    expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
+  });
 });


### PR DESCRIPTION
## Summary
- show base prompt box by default
- add a Randomize All toggle
- allow negative prompts to include positive modifiers when toggled
- support randomize all in script and add tests for new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684969e6a90c8321b39bfa0903308822