### PR TITLE
Add tri-state initial state for all-hide toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
           <div class="label-row">
             <label>Quick Actions</label>
             <input type="checkbox" id="all-random" hidden>
-            <button type="button" class="toggle-button" data-target="all-random" data-on="All randomized" data-off="All Canonical">All Canonical</button>
+            <button type="button" class="toggle-button" data-target="all-random" data-on="All randomized" data-off="All Canonical" data-third="Randomize all">All Canonical</button>
             <input type="checkbox" id="all-hide" hidden>
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible" data-third="Hide all">Hide all</button>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -37,8 +37,8 @@
             <label>Quick Actions</label>
             <input type="checkbox" id="all-random" hidden>
             <button type="button" class="toggle-button" data-target="all-random" data-on="All randomized" data-off="All Canonical">All Canonical</button>
-            <input type="checkbox" id="all-hide" checked hidden>
-            <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All hidden</button>
+            <input type="checkbox" id="all-hide" hidden>
+            <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible" data-third="Hide all">Hide all</button>
           </div>
         </div>
         <!-- Base prompt input section -->

--- a/src/script.js
+++ b/src/script.js
@@ -280,7 +280,11 @@ function generate() {
 function updateButtonState(btn, checkbox) {
   btn.classList.toggle('active', checkbox.checked);
   if (btn.dataset.on && btn.dataset.off) {
-    btn.textContent = checkbox.checked ? btn.dataset.on : btn.dataset.off;
+    if (checkbox.indeterminate && btn.dataset.third) {
+      btn.textContent = btn.dataset.third;
+    } else {
+      btn.textContent = checkbox.checked ? btn.dataset.on : btn.dataset.off;
+    }
   }
 }
 
@@ -292,7 +296,12 @@ function setupToggleButtons() {
     if (!checkbox) return;
     updateButtonState(btn, checkbox);
     btn.addEventListener('click', () => {
-      checkbox.checked = !checkbox.checked;
+      if (checkbox.indeterminate) {
+        checkbox.indeterminate = false;
+        checkbox.checked = true;
+      } else {
+        checkbox.checked = !checkbox.checked;
+      }
       updateButtonState(btn, checkbox);
       checkbox.dispatchEvent(new Event('change'));
     });
@@ -375,11 +384,13 @@ function initializeUI() {
   setupPresetListener('length-select', 'length-input', LENGTH_PRESETS);
   document.getElementById('generate').addEventListener('click', generate);
 
+  const allHide = document.getElementById('all-hide');
+  if (allHide) allHide.indeterminate = true;
+
   setupToggleButtons();
   setupShuffleAll();
   const hideCheckboxes = setupHideToggles();
 
-  const allHide = document.getElementById('all-hide');
   if (allHide) {
     allHide.addEventListener('change', () => {
       hideCheckboxes.forEach(cb => {


### PR DESCRIPTION
## Summary
- make `All hidden` toggle start indeterminate
- allow toggle buttons to handle a third state via `data-third`
- update UI initialization to start with an indeterminate all-hide checkbox

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684972df54b083218834b06e407cad75