### PR TITLE
Preserve delimiters in parseInput

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -38,12 +38,33 @@ describe('Prompt building', () => {
 
   test('buildVersions builds positive and negative prompts', () => {
     const items = parseInput('cat, dog');
-    const out = buildVersions(items, ['bad'], ['good'], false, false, false, 18);
+    const out = buildVersions(items, ['bad'], ['good'], false, false, false, 25);
     expect(out).toEqual({ positive: 'good cat, good dog', negative: 'bad cat, bad dog' });
+  });
+
+  test('buildVersions repeats items with trailing delimiter', () => {
+    const items = parseInput('1, 2, 3, ');
+    const out = buildVersions(items, [], [], false, false, false, 40);
+    expect(out.positive.startsWith('1, 2, 3, 1, 2, 3,'))
+      .toBe(true);
+    expect(out.positive.length).toBeLessThanOrEqual(40);
+  });
+
+  test('buildVersions applies long positive list', () => {
+    const fs = require('fs');
+    const vm = require('vm');
+    const src = fs.readFileSync(require.resolve('../src/lists/good_lists.js'), 'utf8');
+    const context = {};
+    vm.runInNewContext(src + ';this.POSITIVE_LISTS = POSITIVE_LISTS;', context);
+    const posMods = context.POSITIVE_LISTS.presets.find(p => p.id === 'image-positive').items;
+    const items = parseInput('1, 2, 3, ');
+    const out = buildVersions(items, [], posMods, false, false, false, 200);
+    expect(out.positive.startsWith('masterpiece 1, best quality 2, high quality 3, top quality 1,'))
+      .toBe(true);
   });
 
   test('buildVersions can include positive terms for negatives', () => {
     const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20, true);
-    expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
+    expect(out).toEqual({ positive: 'good cat, ', negative: 'bad good cat, ' });
   });
 });


### PR DESCRIPTION
## Summary
- preserve delimiters when parsing input
- update tests for new parse behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849788c388c8321bd9a09105e20ff02