### PR TITLE
Enhance delimiter handling for base prompts

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -121,9 +121,21 @@ function parseInput(raw, keepDelim = false) {
     const ch = normalized[i];
     current += ch;
     if (delims.includes(ch)) {
-      while (i + 1 < normalized.length && normalized[i + 1] === ' ') {
-        current += ' ';
-        i++;
+      let natural = /[,.!:;?\n]/.test(ch);
+      while (i + 1 < normalized.length) {
+        const next = normalized[i + 1];
+        if (delims.includes(next)) {
+          if (/[,.!:;?\n]/.test(next)) natural = true;
+          current += next;
+          i++;
+          continue;
+        }
+        if (next === ' ' && natural) {
+          current += ' ';
+          i++;
+          continue;
+        }
+        break;
       }
       items.push(current);
       current = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -17,6 +17,11 @@ describe('Utility functions', () => {
     expect(parseInput(input, true)).toEqual(['a, ', 'b. ', 'c. ']);
   });
 
+  test('parseInput handles multiple delimiters together', () => {
+    const input = 'a,,. b';
+    expect(parseInput(input, true)).toEqual(['a,,. ', 'b. ']);
+  });
+
   test('shuffle retains all items', () => {
     const arr = [1, 2, 3, 4];
     const result = shuffle(arr.slice());


### PR DESCRIPTION
## Summary
- preserve delimiters when parsing base prompts
- support optional delimiter-aware prefix building
- adapt generation logic for delimiter-aware items
- cover new behaviour with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684983e8c2c48321a36c75a775fbaaf0