### PR TITLE
Improve test coverage and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ This runs the Jest test suite located under `tests/`.
 
 Whenever you modify any JavaScript logic, especially functions in
 `src/script.js`, add or update the corresponding tests to keep coverage up to
-date.
+date. Tests should exercise edge cases and boundary conditions so that unusual
+inputs do not cause regressions.
 
 ## Conventions
 
@@ -25,6 +26,13 @@ date.
 * Keep HTML and CSS under the `src/` directory.
 * Avoid introducing build steps; the tool should remain fully client side.
 * Prefer modular, reusable code, that assumes the underlying structure may change over time ie functional programming is preferred over OOP
+
+## Code Health
+
+Be wary of code "ballooning" where older structures linger and complicate the
+current direction of the program. When a simpler or more efficient approach is
+apparent, refactor instead of layering on more code. Keep functions short and
+focused and remove obsolete parts when revising features.
 
 ## Lists Folder
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -22,6 +22,18 @@ describe('Utility functions', () => {
     expect(parseInput(input, true)).toEqual(['a,,. ', 'b. ']);
   });
 
+  test('parseInput returns empty array for empty input', () => {
+    expect(parseInput('')).toEqual([]);
+  });
+
+  test('parseInput adds punctuation when missing delimiters', () => {
+    expect(parseInput('abc', true)).toEqual(['abc. ']);
+  });
+
+  test('parseInput preserves consecutive newlines', () => {
+    expect(parseInput('a\n\nb', true)).toEqual(['a\n\n', 'b. ']);
+  });
+
   test('shuffle retains all items', () => {
     const arr = [1, 2, 3, 4];
     const result = shuffle(arr.slice());
@@ -41,6 +53,19 @@ describe('Prompt building', () => {
     expect(result).toEqual(['x a']);
   });
 
+  test('buildPrefixedList returns empty when limit too small', () => {
+    expect(buildPrefixedList(['a'], ['x'], 2)).toEqual([]);
+  });
+
+  test('buildPrefixedList falls back to items when prefixes empty', () => {
+    const result = buildPrefixedList(['a', 'b'], [], 10);
+    expect(result).toEqual(['a', 'b', 'a', 'b']);
+  });
+
+  test('buildPrefixedList handles empty items', () => {
+    expect(buildPrefixedList([], ['x'], 10)).toEqual([]);
+  });
+
   test('buildVersions builds positive and negative prompts', () => {
     const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20);
     expect(out).toEqual({ positive: 'good cat, good cat', negative: 'bad cat, bad cat' });
@@ -49,5 +74,23 @@ describe('Prompt building', () => {
   test('buildVersions can include positive terms for negatives', () => {
     const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20, true);
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
+  });
+
+  test('buildVersions returns empty strings when items list is empty', () => {
+    const out = buildVersions([], ['n'], ['p'], false, false, false, 10);
+    expect(out).toEqual({ positive: '', negative: '' });
+  });
+
+  test('buildVersions respects very small limits', () => {
+    const out = buildVersions(['hello'], ['n'], ['p'], false, false, false, 2);
+    expect(out).toEqual({ positive: '', negative: '' });
+  });
+
+  test('buildVersions joins items without commas when delimited', () => {
+    const out = buildVersions(['a.\n', 'b.\n'], ['n'], ['p'], false, false, false, 30);
+    expect(out.positive.includes(',')).toBe(false);
+    expect(out.negative.includes(',')).toBe(false);
+    expect(out.positive.startsWith('p a.\n')).toBe(true);
+    expect(out.positive.endsWith('\n')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expand Jest tests to cover edge cases
- update AGENTS instructions with guidance on edge case testing and code health

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498866287c8321bcf130be94fdc275