### PR TITLE
Fix copy button reset for negative prompts

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -421,12 +421,17 @@ function setupCopyButtons() {
   document.querySelectorAll('.copy-button').forEach(btn => {
     const target = document.getElementById(btn.dataset.target);
     if (!target) return;
+    // Preserve the original button label for reliable reset
+    if (!btn.dataset.orig) {
+      btn.dataset.orig = btn.textContent;
+    }
     btn.addEventListener('click', async () => {
       try {
         await navigator.clipboard.writeText(target.textContent);
-        const orig = btn.textContent;
         btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = orig; }, 1000);
+        setTimeout(() => {
+          btn.textContent = btn.dataset.orig;
+        }, 1000);
       } catch (err) {
         console.error('Copy failed', err);
       }


### PR DESCRIPTION
## Summary
- preserve original label on copy buttons
- reset to stored label after copying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a9c0a809483219f9b6e6d662c9c2e