### PR TITLE
Add lyrics processor

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -90,12 +90,28 @@
             <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
             <button type="button" class="toggle-button" data-target="length-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
-          <select id="length-select">
-            <!-- Options will be populated dynamically from LENGTH_LISTS -->
-          </select>
-          <input type="number" id="length-input" value="1000" min="1">
+        <select id="length-select">
+          <!-- Options will be populated dynamically from LENGTH_LISTS -->
+        </select>
+        <input type="number" id="length-input" value="1000" min="1">
+      </div>
+      <!-- Lyrics processing input -->
+      <div class="input-group">
+        <div class="label-row">
+          <label for="lyrics-input">Lyrics</label>
+          <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-hide" data-on="Hidden" data-off="Visible">Visible</button>
         </div>
-        <!-- Action buttons -->
+        <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
+        <select id="lyrics-space">
+          <option value="1">1</option>
+          <option value="2" selected>2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+        </select>
+      </div>
+      <!-- Action buttons -->
         <button id="generate">Generate</button>
         
         <!-- Output display section -->
@@ -112,6 +128,12 @@
             <button type="button" class="toggle-button" data-target="negative-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </h2>
           <pre id="negative-output"></pre>
+          <h2><span>Processed Lyrics</span>
+            <input type="checkbox" id="lyrics-output-hide" data-targets="lyrics-output" hidden>
+            <button type="button" class="copy-button" data-target="lyrics-output">Copy</button>
+            <button type="button" class="toggle-button" data-target="lyrics-output-hide" data-on="Hidden" data-off="Visible">Visible</button>
+          </h2>
+          <pre id="lyrics-output"></pre>
         </div>
       </div>
     </div>

--- a/src/script.js
+++ b/src/script.js
@@ -276,6 +276,33 @@ function buildVersions(
 }
 
 /**
+ * Processes a lyrics string by removing punctuation, collapsing line breaks
+ * and spaces, lowercasing, then inserting a random number of spaces between
+ * each word.
+ *
+ * @param {string} text - Raw lyrics text
+ * @param {number} maxSpaces - Maximum number of spaces to insert
+ * @returns {string} The processed lyrics string
+ */
+function processLyrics(text, maxSpaces) {
+  if (!text) return '';
+  const limit = parseInt(maxSpaces, 10);
+  const max = !isNaN(limit) && limit > 0 ? limit : 1;
+  let cleaned = text.toLowerCase();
+  cleaned = cleaned.replace(/[^\w\s]/g, '');
+  cleaned = cleaned.replace(/\r?\n/g, ' ');
+  cleaned = cleaned.replace(/\s+/g, ' ').trim();
+  const words = cleaned.split(' ');
+  return words
+    .map((w, i) => {
+      if (i === words.length - 1) return w;
+      const spaces = 1 + Math.floor(Math.random() * max);
+      return w + ' '.repeat(spaces);
+    })
+    .join('');
+}
+
+/**
  * Loads the selected preset into the textarea
  *
  * @param {HTMLSelectElement} selectEl - Dropdown element
@@ -352,6 +379,17 @@ function generate() {
   }
   const result = buildVersions(baseItems, negMods, posMods, shuffleBase, shuffleNeg, shufflePos, limit, includePosForNeg);
   displayOutput(result);
+
+  const lyricsInput = document.getElementById('lyrics-input');
+  if (lyricsInput && lyricsInput.value.trim()) {
+    const spaceSel = document.getElementById('lyrics-space');
+    const maxSpaces = spaceSel ? spaceSel.value : 1;
+    const processed = processLyrics(lyricsInput.value, maxSpaces);
+    document.getElementById('lyrics-output').textContent = processed;
+  } else {
+    const out = document.getElementById('lyrics-output');
+    if (out) out.textContent = '';
+  }
 }
 
 // Update button appearance and text based on checkbox state
@@ -497,5 +535,6 @@ if (typeof module !== 'undefined') {
     equalizeLength,
     buildPrefixedList,
     buildVersions,
+    processLyrics,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4,6 +4,7 @@ const {
   equalizeLength,
   buildPrefixedList,
   buildVersions,
+  processLyrics,
 } = require('../src/script');
 
 describe('Utility functions', () => {
@@ -92,5 +93,21 @@ describe('Prompt building', () => {
     expect(out.negative.includes(',')).toBe(false);
     expect(out.positive.startsWith('p a.\n')).toBe(true);
     expect(out.positive.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('Lyrics processing', () => {
+  test('processLyrics normalizes text with max 1 space', () => {
+    const input = 'Hello, WORLD!\nThis is? a TEST.';
+    const out = processLyrics(input, 1);
+    expect(out).toBe('hello world this is a test');
+  });
+
+  test('processLyrics inserts random spaces up to max', () => {
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0.9);
+    const out = processLyrics('a b', 3);
+    Math.random = orig;
+    expect(out).toBe('a   b');
   });
 });


### PR DESCRIPTION
## Summary
- add lyrics input area and output section
- implement `processLyrics` function
- display processed lyrics on generate
- test lyrics processing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa94381a483219dcd92714d12cc2d