### PR TITLE
Add lyrics cleanup options

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -99,17 +99,24 @@
       <div class="input-group">
         <div class="label-row">
           <label for="lyrics-input">Lyrics</label>
-          <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space" hidden>
+          <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-paren,lyrics-remove-brackets" hidden>
           <button type="button" class="toggle-button" data-target="lyrics-hide" data-on="Hidden" data-off="Visible">Visible</button>
         </div>
         <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
-        <select id="lyrics-space">
-          <option value="1">1</option>
-          <option value="2" selected>2</option>
-          <option value="3">3</option>
-          <option value="4">4</option>
-          <option value="5">5</option>
-        </select>
+        <div class="label-row">
+          <label for="lyrics-space">Max Spaces</label>
+          <select id="lyrics-space">
+            <option value="1">1</option>
+            <option value="2" selected>2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+          </select>
+          <input type="checkbox" id="lyrics-remove-paren" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-remove-paren" data-on="Parenthesis Removed" data-off="Parenthesis Kept">Parenthesis Kept</button>
+          <input type="checkbox" id="lyrics-remove-brackets" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
+        </div>
       </div>
       <!-- Action buttons -->
         <button id="generate">Generate</button>

--- a/src/script.js
+++ b/src/script.js
@@ -282,13 +282,23 @@ function buildVersions(
  *
  * @param {string} text - Raw lyrics text
  * @param {number} maxSpaces - Maximum number of spaces to insert
+ * @param {boolean} removeParen - Whether to remove content inside parentheses
+ * @param {boolean} removeBrackets - Whether to remove content inside any brackets
  * @returns {string} The processed lyrics string
  */
-function processLyrics(text, maxSpaces) {
+function processLyrics(text, maxSpaces, removeParen = false, removeBrackets = false) {
   if (!text) return '';
   const limit = parseInt(maxSpaces, 10);
   const max = !isNaN(limit) && limit > 0 ? limit : 1;
   let cleaned = text.toLowerCase();
+
+  if (removeParen) {
+    cleaned = cleaned.replace(/\([^)]*\)/g, ' ');
+  }
+  if (removeBrackets) {
+    cleaned = cleaned.replace(/\[[^\]]*\]|\{[^}]*\}|<[^>]*>/g, ' ');
+  }
+
   cleaned = cleaned.replace(/[^\w\s]/g, '');
   cleaned = cleaned.replace(/\r?\n/g, ' ');
   cleaned = cleaned.replace(/\s+/g, ' ').trim();
@@ -384,7 +394,14 @@ function generate() {
   if (lyricsInput && lyricsInput.value.trim()) {
     const spaceSel = document.getElementById('lyrics-space');
     const maxSpaces = spaceSel ? spaceSel.value : 1;
-    const processed = processLyrics(lyricsInput.value, maxSpaces);
+    const parenCb = document.getElementById('lyrics-remove-paren');
+    const bracketCb = document.getElementById('lyrics-remove-brackets');
+    const processed = processLyrics(
+      lyricsInput.value,
+      maxSpaces,
+      parenCb ? parenCb.checked : false,
+      bracketCb ? bracketCb.checked : false
+    );
     document.getElementById('lyrics-output').textContent = processed;
   } else {
     const out = document.getElementById('lyrics-output');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -110,4 +110,14 @@ describe('Lyrics processing', () => {
     Math.random = orig;
     expect(out).toBe('a   b');
   });
+
+  test('processLyrics removes parenthetical content', () => {
+    const out = processLyrics('hello (skip) world', 1, true, false);
+    expect(out).toBe('hello world');
+  });
+
+  test('processLyrics removes bracketed content', () => {
+    const out = processLyrics('hello [skip] {also} world', 1, false, true);
+    expect(out).toBe('hello world');
+  });
 });


### PR DESCRIPTION
## Summary
- label the space selector
- add toggles for removing parenthetical and bracketed text
- support removing parenthesis and bracketed words in `processLyrics`
- test new lyrics cleanup options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685faeabdf78832185fde6b2a89e08d4