### PR TITLE
Allow up to 10 spaces in lyrics processing

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -123,6 +123,11 @@
           <option value="3">3</option>
           <option value="4">4</option>
           <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
         </select>
       </div>
       <!-- Action buttons -->

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -186,6 +186,14 @@ describe('Lyrics processing', () => {
     expect(out).toBe('a   b');
   });
 
+  test('processLyrics handles up to 10 spaces', () => {
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0.9);
+    const out = processLyrics('a b', 10);
+    Math.random = orig;
+    expect(out).toBe('a          b');
+  });
+
   test('processLyrics removes parenthetical content when requested', () => {
     const input = 'hello (remove me) world';
     const out = processLyrics(input, 1, true, false);


### PR DESCRIPTION
## Summary
- update `lyrics-space` dropdown to include values 6–10
- verify `processLyrics` can insert up to 10 spaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68627b4a29ec8321a29a0b2d95a14abb