### PR TITLE
Add stack size modifiers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,11 +64,14 @@
         <div class="input-group">
           <div class="label-row">
             <label for="pos-input">Positive Modifier List</label>
+            <input type="checkbox" id="pos-stack" hidden>
+            <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
             <input type="checkbox" id="pos-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="pos-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
             <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
             <button type="button" class="toggle-button" data-target="pos-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
+          <input type="number" id="pos-stack-size" value="1" min="1" max="4" style="display:none;width:60px">
           <select id="pos-select">
             <!-- Options will be populated dynamically from POSITIVE_LISTS -->
           </select>
@@ -78,6 +81,8 @@
         <div class="input-group">
           <div class="label-row">
             <label for="neg-input">Negative Modifier List</label>
+            <input type="checkbox" id="neg-stack" hidden>
+            <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
             <input type="checkbox" id="neg-include-pos" hidden>
             <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
             <input type="checkbox" id="neg-shuffle" hidden>
@@ -85,6 +90,7 @@
             <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
             <button type="button" class="toggle-button" data-target="neg-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
+          <input type="number" id="neg-stack-size" value="1" min="1" max="4" style="display:none;width:60px">
           <select id="neg-select">
             <!-- Options will be populated dynamically from NEGATIVE_LISTS -->
           </select>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -157,6 +157,24 @@ describe('Prompt building', () => {
     expect(out.positive).toContain('\nfoo ');
     expect(out.positive.startsWith('a, b')).toBe(true);
   });
+
+  test('buildVersions supports stacked modifiers', () => {
+    const out = buildVersions(
+      ['x'],
+      ['n'],
+      ['p'],
+      false,
+      false,
+      false,
+      50,
+      false,
+      [],
+      2,
+      2
+    );
+    expect(out.positive.startsWith('p p ')).toBe(true);
+    expect(out.negative.startsWith('n n ')).toBe(true);
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- add stack controls to modifier sections
- support stacked modifier generation
- handle new inputs for stack size
- test stacked modifier functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686389d1da68832191c6be2dab24a4c3