### PR TITLE
Implement modifier stacking

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -66,6 +66,9 @@
             <label for="pos-input">Positive Modifier List</label>
             <input type="checkbox" id="pos-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="pos-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
+            <input type="checkbox" id="pos-stack" hidden>
+            <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
+            <input type="number" id="pos-stack-size" class="stack-size" value="2" min="1" max="4" style="display:none">
             <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
             <button type="button" class="toggle-button" data-target="pos-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
@@ -82,6 +85,9 @@
             <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
             <input type="checkbox" id="neg-shuffle" hidden>
             <button type="button" class="toggle-button" data-target="neg-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
+            <input type="checkbox" id="neg-stack" hidden>
+            <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
+            <input type="number" id="neg-stack-size" class="stack-size" value="2" min="1" max="4" style="display:none">
             <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
             <button type="button" class="toggle-button" data-target="neg-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>

--- a/src/style.css
+++ b/src/style.css
@@ -354,6 +354,12 @@ input[type=number] {
     margin-top: 0.5rem;
 }
 
+.stack-size {
+  width: 4rem;
+  margin-left: 0.5rem;
+  margin-top: 0;
+}
+
 /* Button styling */
 button {
     margin-right: 0.5rem;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3,6 +3,7 @@ const {
   shuffle,
   equalizeLength,
   buildPrefixedList,
+  buildStackedList,
   buildVersions,
   processLyrics,
 } = require('../src/script');
@@ -77,28 +78,69 @@ describe('Prompt building', () => {
     expect(result).toEqual(['a', 'b']);
   });
 
+  test('buildStackedList repeats modifiers by stack size', () => {
+    const result = buildStackedList(['x'], ['a', 'b'], 2, 10, false, false, []);
+    expect(result).toEqual(['a x', 'b x', 'a x', 'b x']);
+  });
+
   test('buildVersions builds positive and negative prompts', () => {
-    const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20);
+    const out = buildVersions(
+      ['cat'],
+      ['bad'],
+      ['good'],
+      false,
+      false,
+      false,
+      20,
+      false,
+      [],
+      1,
+      1
+    );
     expect(out).toEqual({ positive: 'good cat, good cat', negative: 'bad cat, bad cat' });
   });
 
   test('buildVersions can include positive terms for negatives', () => {
-    const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20, true);
+    const out = buildVersions(
+      ['cat'],
+      ['bad'],
+      ['good'],
+      false,
+      false,
+      false,
+      20,
+      true,
+      [],
+      1,
+      1
+    );
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
   });
 
   test('buildVersions returns empty strings when items list is empty', () => {
-    const out = buildVersions([], ['n'], ['p'], false, false, false, 10);
+    const out = buildVersions([], ['n'], ['p'], false, false, false, 10, false, [], 1, 1);
     expect(out).toEqual({ positive: '', negative: '' });
   });
 
   test('buildVersions respects very small limits', () => {
-    const out = buildVersions(['hello'], ['n'], ['p'], false, false, false, 2);
+    const out = buildVersions(['hello'], ['n'], ['p'], false, false, false, 2, false, [], 1, 1);
     expect(out).toEqual({ positive: '', negative: '' });
   });
 
   test('buildVersions joins items without commas when delimited', () => {
-    const out = buildVersions(['a.\n', 'b.\n'], ['n'], ['p'], false, false, false, 30);
+    const out = buildVersions(
+      ['a.\n', 'b.\n'],
+      ['n'],
+      ['p'],
+      false,
+      false,
+      false,
+      30,
+      false,
+      [],
+      1,
+      1
+    );
     expect(out.positive.includes(',')).toBe(false);
     expect(out.negative.includes(',')).toBe(false);
     expect(out.positive.startsWith('p a.\n')).toBe(true);
@@ -115,7 +157,9 @@ describe('Prompt building', () => {
       false,
       50,
       false,
-      ['i.e., ']
+      ['i.e., '],
+      1,
+      1
     );
     expect(out.positive.includes('i.e.,')).toBe(true);
     expect(out.positive.startsWith('a, b, i.e., ')).toBe(true);
@@ -133,7 +177,9 @@ describe('Prompt building', () => {
       false,
       50,
       false,
-      ['x ', 'y ']
+      ['x ', 'y '],
+      1,
+      1
     );
     Math.random = orig;
     const posDivs = out.positive.match(/[xy] /g);
@@ -152,7 +198,9 @@ describe('Prompt building', () => {
       false,
       50,
       false,
-      ['\nfoo ']
+      ['\nfoo '],
+      1,
+      1
     );
     expect(out.positive).toContain('\nfoo ');
     expect(out.positive.startsWith('a, b')).toBe(true);


### PR DESCRIPTION
## Summary
- add stack-size controls for positive and negative modifier lists in the UI
- support multiple randomized stacks when generating prompts
- disable shuffle buttons while stacking is active
- add `.stack-size` styling
- expand tests to cover stacked lists and updated function signatures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686389d1da68832191c6be2dab24a4c3