### PR TITLE
Remove trailing divider from generated prompts

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -195,6 +195,23 @@ function equalizeLength(a, b) {
 }
 
 /**
+ * Removes any trailing divider elements from an array.
+ *
+ * @param {Array} arr - Array to trim
+ * @param {string[]} dividers - Divider strings to remove
+ * @returns {Array} New array without trailing dividers
+ */
+function removeTrailingDivider(arr, dividers) {
+  if (!Array.isArray(arr) || arr.length === 0) return arr;
+  const set = new Set(Array.isArray(dividers) ? dividers : [dividers]);
+  let end = arr.length;
+  while (end > 0 && set.has(arr[end - 1])) {
+    end--;
+  }
+  return arr.slice(0, end);
+}
+
+/**
  * Builds a comma-separated list by pairing items with prefixes
  * until the character limit is reached.
  *
@@ -307,9 +324,16 @@ function buildVersions(
 
   const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
 
+  const cleanNeg = dividerPool.length
+    ? removeTrailingDivider(trimNeg, dividerPool)
+    : trimNeg;
+  const cleanPos = dividerPool.length
+    ? removeTrailingDivider(trimPos, dividerPool)
+    : trimPos;
+
   return {
-    positive: trimPos.join(delimited ? '' : ', '),
-    negative: trimNeg.join(delimited ? '' : ', ')
+    positive: cleanPos.join(delimited ? '' : ', '),
+    negative: cleanNeg.join(delimited ? '' : ', ')
   };
 }
 
@@ -595,6 +619,7 @@ if (typeof module !== 'undefined') {
     parseInput,
     shuffle,
     equalizeLength,
+    removeTrailingDivider,
     buildPrefixedList,
     buildVersions,
     processLyrics,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -157,6 +157,38 @@ describe('Prompt building', () => {
     expect(out.positive).toContain('\nfoo ');
     expect(out.positive.startsWith('a, b')).toBe(true);
   });
+
+  test('buildVersions never ends with a natural divider', () => {
+    const NAT_DIVS = [
+      '\nIn other words, ',
+      '\ni.e., ',
+      '\nPut another way, ',
+      '\nRestated, ',
+      '\nWhich is to say, ',
+      '\nTo be precise, ',
+      '\nIn essence, ',
+      '\nPut differently, ',
+      '\nTo put it another way, ',
+      '\nThat is to say, ',
+      '\nNamely, ',
+      '\nRephrased, ',
+      '\nTo say it another way, ',
+      '\nLet me put it this way. '
+    ];
+    const out = buildVersions(
+      ['alpha'],
+      [],
+      [],
+      false,
+      false,
+      false,
+      30,
+      false,
+      NAT_DIVS
+    );
+    expect(NAT_DIVS.some(d => out.positive.endsWith(d))).toBe(false);
+    expect(NAT_DIVS.some(d => out.negative.endsWith(d))).toBe(false);
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- add `removeTrailingDivider` helper
- trim generated lists to remove a trailing divider when using natural dividers
- test that prompts never end with a divider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686396c2b1f08321b6b21e1395cf4ce8