### PR TITLE
Add trailing divider cleanup

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -195,6 +195,21 @@ function equalizeLength(a, b) {
 }
 
 /**
+ * Removes a trailing divider from an array if present
+ *
+ * @param {Array} arr - Array that may end with a divider
+ * @param {string[]} dividers - Divider strings to remove
+ * @returns {Array} A copy of the array without a trailing divider
+ */
+function removeTrailingDivider(arr, dividers = []) {
+  const out = arr.slice();
+  while (out.length && dividers.includes(out[out.length - 1])) {
+    out.pop();
+  }
+  return out;
+}
+
+/**
  * Builds a comma-separated list by pairing items with prefixes
  * until the character limit is reached.
  *
@@ -366,9 +381,16 @@ function buildVersions(
 
   const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
 
+  let finalNeg = trimNeg;
+  let finalPos = trimPos;
+  if (dividerPool.length) {
+    finalNeg = removeTrailingDivider(trimNeg, dividerPool);
+    finalPos = removeTrailingDivider(trimPos, dividerPool);
+  }
+
   return {
-    positive: trimPos.join(delimited ? '' : ', '),
-    negative: trimNeg.join(delimited ? '' : ', ')
+    positive: finalPos.join(delimited ? '' : ', '),
+    negative: finalNeg.join(delimited ? '' : ', ')
   };
 }
 
@@ -748,6 +770,7 @@ if (typeof module !== 'undefined') {
     parseInput,
     shuffle,
     equalizeLength,
+    removeTrailingDivider,
     buildPrefixedList,
     applyModifierStack,
     buildVersions,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -206,6 +206,23 @@ describe('Prompt building', () => {
     const divMatches = out.positive.match(/, \nfoo /g) || [];
     expect(divMatches.length).toBeGreaterThan(0);
   });
+
+  test('output never ends with a divider under tight limits', () => {
+    const out = buildVersions(
+      ['a', 'b'],
+      [],
+      [],
+      false,
+      false,
+      false,
+      25,
+      false,
+      ['\nfoo ']
+    );
+    expect(out.positive.endsWith('\nfoo ')).toBe(false);
+    expect(out.negative.endsWith('\nfoo ')).toBe(false);
+    expect(out.positive.includes('\nfoo ')).toBe(true);
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- add `removeTrailingDivider` helper
- ensure dividers trimmed in `buildVersions`
- test natural dividers to ensure results never end with the divider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639854cbd48321bad9574183cd3ebc