### PR TITLE
Handle trailing natural dividers

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -195,6 +195,21 @@ function equalizeLength(a, b) {
 }
 
 /**
+ * Removes the final array element if it matches one of the divider strings.
+ *
+ * @param {Array} arr - Array potentially ending in a divider
+ * @param {string[]} dividers - Divider strings to check against
+ * @returns {Array} New array without a trailing divider
+ */
+function removeTrailingDivider(arr, dividers) {
+  const copy = arr.slice();
+  if (copy.length && dividers.includes(copy[copy.length - 1])) {
+    copy.pop();
+  }
+  return copy;
+}
+
+/**
  * Builds a comma-separated list by pairing items with prefixes
  * until the character limit is reached.
  *
@@ -353,7 +368,11 @@ function buildVersions(
     delimited,
     dividerPool
   );
-  const negBase = includePosForNeg ? posTerms : items;
+  let negBase = items;
+  if (includePosForNeg) {
+    const filtered = posTerms.filter(t => !dividers.includes(t));
+    negBase = filtered.slice(0, items.length);
+  }
   const negTerms = applyModifierStack(
     negBase,
     negMods,
@@ -366,9 +385,13 @@ function buildVersions(
 
   const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
 
+  const natural = dividers.length && dividers[0].startsWith('\n');
+  const finalNeg = natural ? removeTrailingDivider(trimNeg, dividers) : trimNeg;
+  const finalPos = natural ? removeTrailingDivider(trimPos, dividers) : trimPos;
+
   return {
-    positive: trimPos.join(delimited ? '' : ', '),
-    negative: trimNeg.join(delimited ? '' : ', ')
+    positive: finalPos.join(delimited ? '' : ', '),
+    negative: finalNeg.join(delimited ? '' : ', ')
   };
 }
 
@@ -748,6 +771,7 @@ if (typeof module !== 'undefined') {
     parseInput,
     shuffle,
     equalizeLength,
+    removeTrailingDivider,
     buildPrefixedList,
     applyModifierStack,
     buildVersions,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -206,6 +206,39 @@ describe('Prompt building', () => {
     const divMatches = out.positive.match(/, \nfoo /g) || [];
     expect(divMatches.length).toBeGreaterThan(0);
   });
+
+  test('natural divider never appears at end', () => {
+    const out = buildVersions(
+      ['a', 'b', 'c'],
+      ['n'],
+      ['p'],
+      false,
+      false,
+      false,
+      35,
+      false,
+      ['\nbar ']
+    );
+    expect(out.positive.trim().endsWith('\nbar')).toBe(false);
+    expect(out.negative.trim().endsWith('\nbar')).toBe(false);
+  });
+
+  test('includePosForNeg handles natural dividers', () => {
+    const out = buildVersions(
+      ['a', 'b'],
+      ['n'],
+      ['p'],
+      false,
+      false,
+      false,
+      100,
+      true,
+      ['\nfoo ']
+    );
+    expect(out.negative).not.toMatch(/n p \nfoo /);
+    const divMatches = out.negative.match(/, \nfoo /g) || [];
+    expect(divMatches.length).toBeGreaterThan(0);
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- add `removeTrailingDivider` helper
- trim trailing natural divider strings in `buildVersions`
- fix natural divider placement for negatives when using positive base
- test that natural dividers never appear at the end or inside prefixed negatives

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68639854cbd48321bad9574183cd3ebc