### PR TITLE
Fix divider placement for negative prompts

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -353,16 +353,40 @@ function buildVersions(
     delimited,
     dividerPool
   );
-  const negBase = includePosForNeg ? posTerms : items;
-  const negTerms = applyModifierStack(
-    negBase,
-    negMods,
-    limit,
-    negStackSize,
-    shuffleNeg,
-    delimited,
-    dividerPool
-  );
+  let negTerms;
+  if (includePosForNeg && dividerPool.length) {
+    const isDivider = term => dividerPool.includes(term);
+    const base = posTerms.filter(t => !isDivider(t));
+    const negRaw = applyModifierStack(
+      base,
+      negMods,
+      limit,
+      negStackSize,
+      shuffleNeg,
+      delimited,
+      []
+    );
+    negTerms = [];
+    let idx = 0;
+    posTerms.forEach(term => {
+      if (isDivider(term)) {
+        negTerms.push(term);
+      } else if (idx < negRaw.length) {
+        negTerms.push(negRaw[idx++]);
+      }
+    });
+  } else {
+    const negBase = includePosForNeg ? posTerms : items;
+    negTerms = applyModifierStack(
+      negBase,
+      negMods,
+      limit,
+      negStackSize,
+      shuffleNeg,
+      delimited,
+      dividerPool
+    );
+  }
 
   const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -206,6 +206,24 @@ describe('Prompt building', () => {
     const divMatches = out.positive.match(/, \nfoo /g) || [];
     expect(divMatches.length).toBeGreaterThan(0);
   });
+
+  test('positives for negatives keep divider placement', () => {
+    const out = buildVersions(
+      ['a'],
+      ['n'],
+      ['p'],
+      false,
+      false,
+      false,
+      50,
+      true,
+      ['div ']
+    );
+    expect(out.negative).not.toMatch(/n div /);
+    const posDivs = out.positive.match(/div /g) || [];
+    const negDivs = out.negative.match(/div /g) || [];
+    expect(negDivs).toEqual(posDivs);
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- handle natural divider logic when negatives build on positives
- test divider placement when including positive modifiers in negatives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a0f11ba08321bc9947219f90fcbc