### PR TITLE
Fix divider placement in negative prompts

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -206,6 +206,22 @@ describe('Prompt building', () => {
     const divMatches = out.positive.match(/, \nfoo /g) || [];
     expect(divMatches.length).toBeGreaterThan(0);
   });
+
+  test('negative preserves divider placement when built on positives', () => {
+    const out = buildVersions(
+      ['cat'],
+      ['bad'],
+      ['good'],
+      false,
+      false,
+      false,
+      50,
+      true,
+      ['\nfoo ']
+    );
+    expect(out.positive).toBe('good cat, \nfoo , good cat, \nfoo ');
+    expect(out.negative).toBe('bad good cat, \nfoo , bad good cat, \nfoo ');
+  });
 });
 
 describe('Lyrics processing', () => {


### PR DESCRIPTION
## Summary
- avoid prefixing natural divider strings when building negative prompts
- keep divider positions consistent by adding new `applyNegativeOnPositive`
- export the new helper
- test divider handling when negatives build on positives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a0f11ba08321bc9947219f90fcbc