### PR TITLE
Side toggle buttons with dice icon

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,13 +60,17 @@
         <div class="input-group">
           <div class="label-row">
             <label for="base-input">Base Prompt List</label>
-            <input type="checkbox" id="base-shuffle" hidden>
-            <button type="button" class="toggle-button" data-target="base-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
-            <button type="button" class="toggle-button" data-target="base-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
-          <textarea id="base-input" rows="4"
-            placeholder="Enter comma, semicolon, or newline separated items"></textarea>
+          <div class="input-row">
+            <textarea id="base-input" rows="4"
+              placeholder="Enter comma, semicolon, or newline separated items"></textarea>
+            <div class="button-col">
+              <input type="checkbox" id="base-shuffle" hidden>
+              <button type="button" class="toggle-button icon-button random-button" data-target="base-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="◀" data-off="▼">▼</button>
+            </div>
+          </div>
         </div>
         <!-- Positive modifier selection section -->
         <div class="input-group">
@@ -74,10 +78,6 @@
             <label for="pos-input">Positive Modifier List</label>
             <input type="checkbox" id="pos-stack" hidden>
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
-            <input type="checkbox" id="pos-shuffle" hidden>
-            <button type="button" class="toggle-button" data-target="pos-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
-            <button type="button" class="toggle-button" data-target="pos-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
           <select id="pos-stack-size" style="display:none">
             <option value="1">1</option>
@@ -93,6 +93,10 @@
             <div class="button-col">
               <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
               <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <input type="checkbox" id="pos-shuffle" hidden>
+              <button type="button" class="toggle-button icon-button random-button" data-target="pos-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>
@@ -104,10 +108,6 @@
             <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
             <input type="checkbox" id="neg-stack" hidden>
             <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
-            <input type="checkbox" id="neg-shuffle" hidden>
-            <button type="button" class="toggle-button" data-target="neg-shuffle" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
-            <button type="button" class="toggle-button" data-target="neg-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
           <select id="neg-stack-size" style="display:none">
             <option value="1">1</option>
@@ -123,6 +123,10 @@
             <div class="button-col">
               <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
               <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <input type="checkbox" id="neg-shuffle" hidden>
+              <button type="button" class="toggle-button icon-button random-button" data-target="neg-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>
@@ -130,8 +134,6 @@
         <div class="input-group">
           <div class="label-row">
             <label for="length-input">Length Limit</label>
-            <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
-            <button type="button" class="toggle-button" data-target="length-hide" data-on="Hidden" data-off="Visible">Visible</button>
           </div>
         <select id="length-select">
           <!-- Options will be populated dynamically from LENGTH_LISTS -->
@@ -141,6 +143,8 @@
           <div class="button-col">
             <button type="button" class="copy-button icon-button" data-target="length-input" title="Copy">&#128203;</button>
             <button type="button" id="length-save" class="save-button icon-button" title="Save">&#128190;</button>
+            <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
+            <button type="button" class="toggle-button icon-button hide-button" data-target="length-hide" data-on="◀" data-off="▼">▼</button>
           </div>
         </div>
       </div>
@@ -152,13 +156,13 @@
           <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
           <input type="checkbox" id="lyrics-remove-brackets" hidden>
           <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
-          <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
-          <button type="button" class="toggle-button" data-target="lyrics-hide" data-on="Hidden" data-off="Visible">Visible</button>
         </div>
         <div class="input-row">
           <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
           <div class="button-col">
             <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
+            <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
+            <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="◀" data-off="▼">▼</button>
           </div>
         </div>
         <div class="label-row">
@@ -182,34 +186,31 @@
         
         <!-- Output display section -->
         <div class="output">
-          <h2><span>Positive Conditioning</span>
-            <input type="checkbox" id="positive-hide" data-targets="positive-output" hidden>
-            <button type="button" class="toggle-button" data-target="positive-hide" data-on="Hidden" data-off="Visible">Visible</button>
-          </h2>
+          <h2><span>Positive Conditioning</span></h2>
           <div class="input-row">
             <pre id="positive-output"></pre>
             <div class="button-col">
               <button type="button" class="copy-button icon-button" data-target="positive-output" title="Copy">&#128203;</button>
+              <input type="checkbox" id="positive-hide" data-targets="positive-output" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="positive-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
-          <h2><span>Negative Conditioning</span>
-            <input type="checkbox" id="negative-hide" data-targets="negative-output" hidden>
-            <button type="button" class="toggle-button" data-target="negative-hide" data-on="Hidden" data-off="Visible">Visible</button>
-          </h2>
+          <h2><span>Negative Conditioning</span></h2>
           <div class="input-row">
             <pre id="negative-output"></pre>
             <div class="button-col">
               <button type="button" class="copy-button icon-button" data-target="negative-output" title="Copy">&#128203;</button>
+              <input type="checkbox" id="negative-hide" data-targets="negative-output" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="negative-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
-          <h2><span>Processed Lyrics</span>
-            <input type="checkbox" id="lyrics-output-hide" data-targets="lyrics-output" hidden>
-            <button type="button" class="toggle-button" data-target="lyrics-output-hide" data-on="Hidden" data-off="Visible">Visible</button>
-          </h2>
+          <h2><span>Processed Lyrics</span></h2>
           <div class="input-row">
             <pre id="lyrics-output"></pre>
             <div class="button-col">
               <button type="button" class="copy-button icon-button" data-target="lyrics-output" title="Copy">&#128203;</button>
+              <input type="checkbox" id="lyrics-output-hide" data-targets="lyrics-output" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-output-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prompt Enhancer</title>
   <link rel="stylesheet" href="style.css">
-  
+
   <!-- Google Analytics tracking -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-D5NMHFTQDK"></script>
   <script>
@@ -24,7 +24,7 @@
   <div class="top-nav">
     <a href="https://www.diskrot.com"><img src="assets/logo.png" width="24" height="24"></a>
   </div>
-  
+
   <!-- Main container -->
   <div class="container">
     <div class="main-content">
@@ -65,10 +65,10 @@
             <textarea id="base-input" rows="4"
               placeholder="Enter comma, semicolon, or newline separated items"></textarea>
             <div class="button-col">
+              <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="☰" data-off="✖">☰</button>
               <input type="checkbox" id="base-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="base-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
-              <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>
@@ -91,12 +91,12 @@
           <div class="input-row">
             <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
             <div class="button-col">
+              <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="☰" data-off="✖">☰</button>
               <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
               <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="pos-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="pos-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
-              <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>
@@ -121,12 +121,12 @@
           <div class="input-row">
             <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
             <div class="button-col">
+              <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="☰" data-off="✖">☰</button>
               <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
               <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="neg-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="neg-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
-              <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="◀" data-off="▼">▼</button>
             </div>
           </div>
         </div>
@@ -141,10 +141,10 @@
         <div class="input-row">
           <input type="number" id="length-input" value="1000" min="1">
           <div class="button-col">
+            <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
+            <button type="button" class="toggle-button icon-button hide-button" data-target="length-hide" data-on="☰" data-off="✖">☰</button>
             <button type="button" class="copy-button icon-button" data-target="length-input" title="Copy">&#128203;</button>
             <button type="button" id="length-save" class="save-button icon-button" title="Save">&#128190;</button>
-            <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
-            <button type="button" class="toggle-button icon-button hide-button" data-target="length-hide" data-on="◀" data-off="▼">▼</button>
           </div>
         </div>
       </div>
@@ -160,9 +160,9 @@
         <div class="input-row">
           <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
           <div class="button-col">
-            <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
             <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
-            <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="◀" data-off="▼">▼</button>
+            <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="☰" data-off="✖">☰</button>
+            <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
           </div>
         </div>
         <div class="label-row">
@@ -183,34 +183,34 @@
       </div>
       <!-- Action buttons -->
         <button id="generate">Generate</button>
-        
+
         <!-- Output display section -->
         <div class="output">
           <h2><span>Positive Conditioning</span></h2>
           <div class="input-row">
             <pre id="positive-output"></pre>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="positive-output" title="Copy">&#128203;</button>
               <input type="checkbox" id="positive-hide" data-targets="positive-output" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="positive-hide" data-on="◀" data-off="▼">▼</button>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="positive-hide" data-on="☰" data-off="✖">☰</button>
+              <button type="button" class="copy-button icon-button" data-target="positive-output" title="Copy">&#128203;</button>
             </div>
           </div>
           <h2><span>Negative Conditioning</span></h2>
           <div class="input-row">
             <pre id="negative-output"></pre>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="negative-output" title="Copy">&#128203;</button>
               <input type="checkbox" id="negative-hide" data-targets="negative-output" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="negative-hide" data-on="◀" data-off="▼">▼</button>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="negative-hide" data-on="☰" data-off="✖">☰</button>
+              <button type="button" class="copy-button icon-button" data-target="negative-output" title="Copy">&#128203;</button>
             </div>
           </div>
           <h2><span>Processed Lyrics</span></h2>
           <div class="input-row">
             <pre id="lyrics-output"></pre>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="lyrics-output" title="Copy">&#128203;</button>
               <input type="checkbox" id="lyrics-output-hide" data-targets="lyrics-output" hidden>
-              <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-output-hide" data-on="◀" data-off="▼">▼</button>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-output-hide" data-on="☰" data-off="✖">☰</button>
+              <button type="button" class="copy-button icon-button" data-target="lyrics-output" title="Copy">&#128203;</button>
             </div>
           </div>
         </div>
@@ -224,7 +224,7 @@
       document.getElementById(id).style.display = 'block';
     }
   </script>
-  
+
   <!-- External script loading order is important -->
   <!-- Load list data files first -->
   <script src="all_lists.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -750,7 +750,21 @@ function setupHideToggles() {
         el.style.display = cb.checked ? 'none' : '';
       });
       const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
-      if (btn) updateButtonState(btn, cb);
+      if (btn) {
+        updateButtonState(btn, cb);
+        const col = btn.parentElement;
+        if (col && col.classList.contains('button-col')) {
+          Array.from(col.children).forEach(child => {
+            if (child !== btn) {
+              child.style.display = cb.checked ? 'none' : '';
+            }
+          });
+          const row = col.parentElement;
+          if (row && row.classList.contains('input-row')) {
+            row.style.justifyContent = cb.checked ? 'flex-end' : '';
+          }
+        }
+      }
     };
     cb.addEventListener('change', update);
     update();

--- a/src/style.css
+++ b/src/style.css
@@ -426,6 +426,7 @@ button {
 .input-row {
   display: flex;
   align-items: flex-start;
+  width: 100%;
 }
 .input-row textarea,
 .input-row input[type=number],
@@ -450,6 +451,25 @@ button {
 }
 .button-col .icon-button:last-child {
   margin-bottom: 0;
+}
+
+.toggle-button.icon-button {
+  background: transparent;
+  border: 1px solid #888;
+  color: #fff;
+}
+
+.icon-button.toggle-button.active {
+  background: transparent;
+  border-color: #0d6efd;
+}
+
+.random-button.active {
+  color: #0d6efd;
+}
+
+.hide-button {
+  font-size: 1rem;
 }
 
 /* Save button styling */

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,6 @@
 /**
  * Prompt Enhancer - Stylesheet
- * 
+ *
  * Dark theme inspired by Diskrot with gradient background
  * Responsive design with mobile-first approach
  */
@@ -397,9 +397,9 @@ button {
     cursor: not-allowed;
 }
 
-.toggle-button.active {
-    background: linear-gradient(45deg, #0d6efd, #6610f2);
-    border-color: transparent;
+.toggle-button:not(.hide-button).active {
+  background: linear-gradient(45deg, #0d6efd, #6610f2);
+  border-color: transparent;
 }
 
 /* Copy button styling */
@@ -459,13 +459,9 @@ button {
   color: #fff;
 }
 
-.icon-button.toggle-button.active {
-  background: transparent;
-  border-color: #0d6efd;
-}
-
 .random-button.active {
-  color: #0d6efd;
+  background: linear-gradient(45deg, #0d6efd, #6610f2);
+  border-color: transparent;
 }
 
 .hide-button {


### PR DESCRIPTION
## Summary
- move hidden and shuffle toggles into the side button column
- add dice and accordion icons for shuffle and hide controls
- collapse other side buttons when an item is hidden
- tweak layout and styling for new side buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864f854d3b48321beb4bf69e754dffc