### PR TITLE
Remove stack size 1 option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -80,7 +80,6 @@
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
           </div>
           <select id="pos-stack-size" style="display:none">
-            <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
             <option value="4">4</option>
@@ -110,7 +109,6 @@
             <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
           </div>
           <select id="neg-stack-size" style="display:none">
-            <option value="1">1</option>
             <option value="2">2</option>
             <option value="3">3</option>
             <option value="4">4</option>


### PR DESCRIPTION
## Summary
- omit stack size `1` from positive and negative stack size dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68650283343c8321a2e0d5f92baef47b