### PR TITLE
Add divider list presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 - **Custom Lists**: Full support for user-defined modifier lists
 - **Smart Cycling**: Automatically cycles through base prompts and modifiers
 - **Randomization Options**: Optional shuffling for each list independently
-- **Natural Dividers**: Repeats are separated by newlines with randomized connecting phrases reused for both versions
+- **Divider Lists**: Choose between simple or natural newline phrases and create your own
 - **Character Limits**: Configurable output length limits (presets for Suno and Riffusion)
 - **No Dependencies**: Pure vanilla JavaScript, works completely offline
 - **Dark Theme**: Eye-friendly interface inspired by Diskrot

--- a/src/all_lists.js
+++ b/src/all_lists.js
@@ -739,6 +739,33 @@ const ALL_LISTS = {
         "10000"
       ],
       "type": "length"
+    },
+    {
+      "id": "divider-simple",
+      "title": "Simple",
+      "items": [],
+      "type": "divider"
+    },
+    {
+      "id": "divider-natural",
+      "title": "Natural",
+      "items": [
+        "In other words, ",
+        "i.e., ",
+        "Put another way, ",
+        "Restated, ",
+        "Which is to say, ",
+        "To be precise, ",
+        "In essence, ",
+        "Put differently, ",
+        "To put it another way, ",
+        "That is to say, ",
+        "Namely, ",
+        "Rephrased, ",
+        "To say it another way, ",
+        "Let me put it this way. "
+      ],
+      "type": "divider"
     }
   ]
 };

--- a/src/index.html
+++ b/src/index.html
@@ -43,9 +43,19 @@
         </div>
         <div class="input-group">
           <div class="label-row">
-            <label>Natural Divider</label>
-            <input type="checkbox" id="nl-divider" hidden>
-            <button type="button" class="toggle-button" data-target="nl-divider" data-on="Natural" data-off="Simple">Simple</button>
+            <label for="divider-input">Divider List</label>
+            <div class="button-col">
+              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
+              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <input type="checkbox" id="divider-shuffle" hidden>
+              <button type="button" class="toggle-button icon-button random-button" data-target="divider-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <input type="checkbox" id="divider-hide" data-targets="divider-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
+            </div>
+          </div>
+          <select id="divider-select"></select>
+          <div class="input-row">
+            <textarea id="divider-input" rows="2" placeholder="Divider phrases"></textarea>
           </div>
         </div>
         <div class="input-group">

--- a/src/script.js
+++ b/src/script.js
@@ -183,8 +183,7 @@ function parseDividerInput(raw) {
   if (!raw) return [];
   return raw
     .split(/\r?\n/)
-    .map(s => s.trim())
-    .filter(Boolean);
+    .filter(line => line !== '');
 }
 
 /**

--- a/src/script.js
+++ b/src/script.js
@@ -14,6 +14,7 @@
 let NEG_PRESETS = {};
 let POS_PRESETS = {};
 let LENGTH_PRESETS = {};
+let DIVIDER_PRESETS = {};
 
 // Combined lists object used for import/export operations
 let LISTS;
@@ -43,22 +44,6 @@ if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
 } else {
   LISTS = { presets: [] };
 }
-const NATURAL_DIVIDERS = [
-  '\nIn other words, ',
-  '\ni.e., ',
-  '\nPut another way, ',
-  '\nRestated, ',
-  '\nWhich is to say, ',
-  '\nTo be precise, ',
-  '\nIn essence, ',
-  '\nPut differently, ',
-  '\nTo put it another way, ',
-  '\nThat is to say, ',
-  '\nNamely, ',
-  '\nRephrased, ',
-  '\nTo say it another way, ',
-  '\nLet me put it this way. '
-];
 
 /**
  * Populates a select element with options from preset data
@@ -91,9 +76,11 @@ function loadLists() {
   NEG_PRESETS = {};
   POS_PRESETS = {};
   LENGTH_PRESETS = {};
+  DIVIDER_PRESETS = {};
   const neg = [];
   const pos = [];
   const len = [];
+  const divs = [];
 
   if (LISTS.presets && Array.isArray(LISTS.presets)) {
     LISTS.presets.forEach(p => {
@@ -106,6 +93,9 @@ function loadLists() {
       } else if (p.type === 'length') {
         LENGTH_PRESETS[p.id] = p.items || [];
         len.push(p);
+      } else if (p.type === 'divider') {
+        DIVIDER_PRESETS[p.id] = p.items || [];
+        divs.push(p);
       }
     });
   }
@@ -118,6 +108,9 @@ function loadLists() {
 
   const lengthSelect = document.getElementById('length-select');
   if (lengthSelect) populateSelect(lengthSelect, len);
+
+  const dividerSelect = document.getElementById('divider-select');
+  if (dividerSelect) populateSelect(dividerSelect, divs);
 
   // Uncomment the following lines for a quick summary when debugging
   // console.log('Lists loaded:', {
@@ -183,6 +176,15 @@ function parseInput(raw, keepDelim = false) {
   }
 
   return items.filter(Boolean);
+}
+
+// Parse divider list where each line represents a divider phrase
+function parseDividerInput(raw) {
+  if (!raw) return [];
+  return raw
+    .split(/\r?\n/)
+    .map(s => s.trim())
+    .filter(Boolean);
 }
 
 /**
@@ -398,6 +400,7 @@ function buildVersions(
   limit,
   includePosForNeg = false,
   dividers = [],
+  shuffleDividers = true,
   posStackSize = 1,
   negStackSize = 1
 ) {
@@ -409,8 +412,8 @@ function buildVersions(
 
   const delimited = /[,.!:;?\n]\s*$/.test(items[0]);
 
-  const dividerPool = dividers.slice();
-  if (dividerPool.length) shuffle(dividerPool);
+  const dividerPool = dividers.map(d => (d.startsWith('\n') ? d : '\n' + d));
+  if (dividerPool.length && shuffleDividers) shuffle(dividerPool);
 
   const posTerms = applyModifierStack(
     items,
@@ -508,6 +511,8 @@ function applyPreset(selectEl, inputEl, presetsOrType) {
       presets = POS_PRESETS;
     } else if (presetsOrType === 'length') {
       presets = LENGTH_PRESETS;
+    } else if (presetsOrType === 'divider') {
+      presets = DIVIDER_PRESETS;
     } else {
       presets = {};
     }
@@ -515,7 +520,8 @@ function applyPreset(selectEl, inputEl, presetsOrType) {
   const key = selectEl.value;
   const list = presets[key] || [];
   if (inputEl.tagName === 'TEXTAREA') {
-    inputEl.value = list.join(', ');
+    const sep = presetsOrType === 'divider' || presets === DIVIDER_PRESETS ? '\n' : ', ';
+    inputEl.value = list.join(sep);
   } else {
     inputEl.value = list[0] || '';
   }
@@ -556,7 +562,10 @@ function collectInputs() {
     document.getElementById('neg-stack-size')?.value || '1',
     10
   );
-  const useNaturalDivider = document.getElementById('nl-divider')?.checked;
+  const dividerMods = parseDividerInput(
+    document.getElementById('divider-input')?.value || ''
+  );
+  const shuffleDividers = document.getElementById('divider-shuffle')?.checked;
   const lengthSelect = document.getElementById('length-select');
   const lengthInput = document.getElementById('length-input');
 
@@ -581,7 +590,8 @@ function collectInputs() {
     negStackSize,
     limit,
     includePosForNeg,
-    useNaturalDivider
+    dividerMods,
+    shuffleDividers
   };
 }
 
@@ -612,13 +622,14 @@ function generate() {
     negStackSize,
     limit,
     includePosForNeg,
-    useNaturalDivider
+    dividerMods,
+    shuffleDividers
   } = collectInputs();
   if (!baseItems.length) {
     alert('Please enter at least one base prompt item.');
     return;
   }
-  const dividers = useNaturalDivider ? NATURAL_DIVIDERS : [];
+  const dividers = dividerMods.length ? dividerMods : [];
   const result = buildVersions(
     baseItems,
     negMods,
@@ -629,6 +640,7 @@ function generate() {
     limit,
     includePosForNeg,
     dividers,
+    shuffleDividers,
     posStackOn ? posStackSize : 1,
     negStackOn ? negStackSize : 1
   );
@@ -843,7 +855,8 @@ function saveList(type) {
   const map = {
     negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
     positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-    length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS }
+    length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
+    divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS }
   };
   const cfg = map[type];
   if (!cfg) return;
@@ -852,7 +865,7 @@ function saveList(type) {
   if (!sel || !inp) return;
   const name = prompt('Enter list name', sel.value);
   if (!name) return;
-  const items = parseInput(inp.value);
+  const items = type === 'divider' ? parseDividerInput(inp.value) : parseInput(inp.value);
   let preset = LISTS.presets.find(p => p.id === name && p.type === type);
   if (!preset) {
     preset = { id: name, title: name, type, items };
@@ -893,10 +906,16 @@ function initializeUI() {
     document.getElementById('length-input'),
     'length'
   );
+  applyPreset(
+    document.getElementById('divider-select'),
+    document.getElementById('divider-input'),
+    'divider'
+  );
 
   setupPresetListener('neg-select', 'neg-input', 'negative');
   setupPresetListener('pos-select', 'pos-input', 'positive');
   setupPresetListener('length-select', 'length-input', 'length');
+  setupPresetListener('divider-select', 'divider-input', 'divider');
   document.getElementById('generate').addEventListener('click', generate);
 
   setupToggleButtons();
@@ -938,6 +957,8 @@ function initializeUI() {
   if (negSave) negSave.addEventListener('click', () => saveList('negative'));
   const lenSave = document.getElementById('length-save');
   if (lenSave) lenSave.addEventListener('click', () => saveList('length'));
+  const divSave = document.getElementById('divider-save');
+  if (divSave) divSave.addEventListener('click', () => saveList('divider'));
 }
 
 // Initialize UI when DOM is ready
@@ -965,6 +986,7 @@ if (typeof module !== 'undefined') {
     setupStackControls,
     setupHideToggles,
     applyPreset,
+    parseDividerInput,
     exportLists,
     importLists,
     saveList,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -55,6 +55,11 @@ describe('Utility functions', () => {
     expect(parseDividerInput(raw)).toEqual(['one', 'two']);
   });
 
+  test('parseDividerInput preserves trailing spaces', () => {
+    const raw = 'foo \nbar  ';
+    expect(parseDividerInput(raw)).toEqual(['foo ', 'bar  ']);
+  });
+
   test('shuffle retains all items', () => {
     const arr = [1, 2, 3, 4];
     const result = shuffle(arr.slice());
@@ -140,6 +145,22 @@ describe('Prompt building', () => {
     );
     expect(out.positive.includes('i.e.,')).toBe(true);
     expect(out.positive.startsWith('a, b, \ni.e., ')).toBe(true);
+  });
+
+  test('buildVersions keeps spaces from parsed divider list', () => {
+    const divs = parseDividerInput('foo ');
+    const out = buildVersions(
+      ['a', 'b'],
+      [],
+      [],
+      false,
+      false,
+      false,
+      50,
+      false,
+      divs
+    );
+    expect(out.positive.startsWith('a, b, \nfoo ')).toBe(true);
   });
 
   test('buildVersions reuses divider order for negatives', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -16,6 +16,7 @@ const {
   setupStackControls,
   setupHideToggles,
   applyPreset,
+  parseDividerInput,
   exportLists,
   importLists,
   saveList,
@@ -47,6 +48,11 @@ describe('Utility functions', () => {
 
   test('parseInput preserves consecutive newlines', () => {
     expect(parseInput('a\n\nb', true)).toEqual(['a\n\n', 'b. ']);
+  });
+
+  test('parseDividerInput splits by line', () => {
+    const raw = 'one\ntwo';
+    expect(parseDividerInput(raw)).toEqual(['one', 'two']);
   });
 
   test('shuffle retains all items', () => {
@@ -129,10 +135,11 @@ describe('Prompt building', () => {
       false,
       50,
       false,
-      ['i.e., ']
+      ['i.e., '],
+      true
     );
     expect(out.positive.includes('i.e.,')).toBe(true);
-    expect(out.positive.startsWith('a, b, i.e., ')).toBe(true);
+    expect(out.positive.startsWith('a, b, \ni.e., ')).toBe(true);
   });
 
   test('buildVersions reuses divider order for negatives', () => {
@@ -185,6 +192,7 @@ describe('Prompt building', () => {
       10,
       false,
       [],
+      true,
       2,
       2
     );
@@ -360,6 +368,21 @@ describe('List persistence', () => {
     expect(opt).not.toBeNull();
   });
 
+  test('saveList works for dividers', () => {
+    document.body.innerHTML = `
+      <select id="divider-select"></select>
+      <textarea id="divider-input">foo\nbar</textarea>
+    `;
+    importLists({ presets: [] });
+    global.prompt = jest.fn().mockReturnValue('div1');
+    saveList('divider');
+    const data = JSON.parse(exportLists());
+    const preset = data.presets.find(p => p.id === 'div1' && p.type === 'divider');
+    expect(preset.items).toEqual(['foo', 'bar']);
+    const opt = document.querySelector('#divider-select option[value="div1"]');
+    expect(opt).not.toBeNull();
+  });
+
   test('sequential save and reload', () => {
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -368,9 +391,11 @@ describe('List persistence', () => {
       <textarea id="neg-input"></textarea>
       <select id="length-select"></select>
       <input id="length-input">
+      <select id="divider-select"></select>
+      <textarea id="divider-input"></textarea>
     `;
     importLists({ presets: [] });
-    let names = ['p1', 'p2', 'n1', 'l1'];
+    let names = ['p1', 'p2', 'n1', 'l1', 'd1'];
     global.prompt = jest.fn(() => names.shift());
     document.getElementById('pos-input').value = 'x';
     saveList('positive');
@@ -380,9 +405,11 @@ describe('List persistence', () => {
     saveList('negative');
     document.getElementById('length-input').value = '5';
     saveList('length');
+    document.getElementById('divider-input').value = 'foo';
+    saveList('divider');
 
     const exported = JSON.parse(exportLists());
-    expect(exported.presets.length).toBe(4);
+    expect(exported.presets.length).toBe(5);
 
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -391,6 +418,8 @@ describe('List persistence', () => {
       <textarea id="neg-input"></textarea>
       <select id="length-select"></select>
       <input id="length-input">
+      <select id="divider-select"></select>
+      <textarea id="divider-input"></textarea>
     `;
     importLists(exported);
     const posSelVals = Array.from(document.querySelectorAll('#pos-select option')).map(o => o.value);
@@ -406,5 +435,10 @@ describe('List persistence', () => {
     posSelect.value = 'p1';
     applyPreset(posSelect, posInput, 'positive');
     expect(posInput.value).toBe('x');
+    const divSelect = document.getElementById('divider-select');
+    const divInput = document.getElementById('divider-input');
+    divSelect.value = 'd1';
+    applyPreset(divSelect, divInput, 'divider');
+    expect(divInput.value).toBe('foo');
   });
 });


### PR DESCRIPTION
## Summary
- convert divider setting into a preset list with natural/simple examples
- allow saving/loading divider lists
- add divider controls to UI
- implement divider parsing logic and shuffle flag
- update tests for new divider functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68679226bd68832198fc0095055b79eb