### PR TITLE
Align button columns

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -435,8 +435,9 @@ button {
 }
 
 .button-col {
-  display: inline-flex;
-  flex-direction: row;
+  display: inline-grid;
+  grid-template-columns: repeat(4, 1.8rem);
+  column-gap: 0.25rem;
   align-items: center;
   margin-left: 0.25rem;
 }
@@ -447,12 +448,11 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
-  margin-left: 0;
-  margin-right: 0.25rem;
 }
-.button-col .icon-button:last-child {
-  margin-right: 0;
-}
+.button-col .random-button { grid-column: 1; }
+.button-col .save-button { grid-column: 2; }
+.button-col .copy-button { grid-column: 3; }
+.button-col .hide-button { grid-column: 4; }
 
 .toggle-button.icon-button {
   background: transparent;


### PR DESCRIPTION
## Summary
- align button columns using CSS grid so missing buttons leave gaps
- reorder buttons so random is left of save and copy is left of hide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867b366eac88321a1c6b534e6b74992