### PR TITLE
Align button columns

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -372,7 +372,7 @@ button {
 /* Checkbox label styling */
 .label-row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     margin-bottom: 0.25rem;
 }
 
@@ -435,8 +435,9 @@ button {
 }
 
 .button-col {
-  display: inline-flex;
-  flex-direction: row;
+  display: inline-grid;
+  grid-template-columns: repeat(4, 1.8rem);
+  column-gap: 0.25rem;
   align-items: center;
   margin-left: 0.25rem;
 }
@@ -447,12 +448,12 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
-  margin-left: 0;
-  margin-right: 0.25rem;
+  margin: 0;
 }
-.button-col .icon-button:last-child {
-  margin-right: 0;
-}
+.button-col .random-button { grid-column: 1; }
+.button-col .save-button { grid-column: 2; }
+.button-col .copy-button { grid-column: 3; }
+.button-col .hide-button { grid-column: 4; }
 
 .toggle-button.icon-button {
   background: transparent;
@@ -485,7 +486,7 @@ button {
 /* ===== OUTPUT SECTION ===== */
 .output h2 {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     text-align: left;
     margin-top: 1rem;
     margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- align button columns using CSS grid so missing buttons leave gaps
- reorder buttons to match requested layout: random then save then copy then hide
- fix grid layout vertical alignment by removing default margins on icon buttons
- top-align button rows so columns line up across different row heights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867b366eac88321a1c6b534e6b74992