### PR TITLE
Fix vertical button alignment

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -435,10 +435,15 @@ button {
 }
 
 .button-col {
-  display: inline-flex;
-  flex-direction: row;
+  display: inline-grid;
+  grid-template-columns: repeat(4, 1.8rem);
+  grid-auto-columns: 1.8rem;
+  column-gap: 0.25rem;
+  justify-items: center;
   align-items: center;
   margin-left: 0.25rem;
+  vertical-align: middle;
+  height: 1.8rem;
 }
 .button-col .icon-button {
   width: 1.8rem;
@@ -447,12 +452,14 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
-  margin-left: 0;
-  margin-right: 0.25rem;
+  margin: 0;
+  line-height: 1;
+  vertical-align: middle;
 }
-.button-col .icon-button:last-child {
-  margin-right: 0;
-}
+.button-col .random-button { grid-column: 1; }
+.button-col .save-button { grid-column: 2; }
+.button-col .copy-button { grid-column: 3; }
+.button-col .hide-button { grid-column: 4; }
 
 .toggle-button.icon-button {
   background: transparent;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+
+const fs = require('fs');
+const path = require('path');
+
+describe('UI layout rules', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../src/style.css'), 'utf8');
+
+  test('button column uses four-grid layout', () => {
+    expect(css).toMatch(/\.button-col\s*{[^}]*grid-template-columns:\s*repeat\(4,\s*1\.8rem\)/);
+  });
+
+  test('icon buttons have uniform size', () => {
+    const rule = /\.button-col\s*\.icon-button\s*{[^}]*}/.exec(css);
+    expect(rule).not.toBeNull();
+    expect(rule[0]).toMatch(/width:\s*1\.8rem/);
+    expect(rule[0]).toMatch(/height:\s*1\.8rem/);
+  });
+
+  test('button order assigned to grid columns', () => {
+    expect(css).toMatch(/\.button-col\s*\.random-button\s*{[^}]*grid-column:\s*1/);
+    expect(css).toMatch(/\.button-col\s*\.save-button\s*{[^}]*grid-column:\s*2/);
+    expect(css).toMatch(/\.button-col\s*\.copy-button\s*{[^}]*grid-column:\s*3/);
+    expect(css).toMatch(/\.button-col\s*\.hide-button\s*{[^}]*grid-column:\s*4/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `grid-auto-columns` and explicit height to `.button-col` so missing buttons keep grid spacing consistent
- set `line-height: 1` on icon buttons to avoid baseline mismatch
- introduce `ui.test.js` to verify CSS grid layout rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867b366eac88321a1c6b534e6b74992