### PR TITLE
Align button columns

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -435,10 +435,12 @@ button {
 }
 
 .button-col {
-  display: inline-flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(4, 1.8rem);
+  column-gap: 0.25rem;
   align-items: center;
   margin-left: 0.25rem;
+  width: 8rem;
 }
 .button-col .icon-button {
   width: 1.8rem;
@@ -447,12 +449,13 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
-  margin-left: 0;
-  margin-right: 0.25rem;
+  margin: 0;
+  vertical-align: middle;
 }
-.button-col .icon-button:last-child {
-  margin-right: 0;
-}
+.button-col .random-button { grid-column: 1; }
+.button-col .save-button { grid-column: 2; }
+.button-col .copy-button { grid-column: 3; }
+.button-col .hide-button { grid-column: 4; }
 
 .toggle-button.icon-button {
   background: transparent;

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,51 @@
+/** @jest-environment jsdom */
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+function setupDOM() {
+  const html = fs.readFileSync('src/index.html', 'utf8');
+  const css = fs.readFileSync('src/style.css', 'utf8');
+  const dom = new JSDOM(html);
+  const style = dom.window.document.createElement('style');
+  style.textContent = css;
+  dom.window.document.head.appendChild(style);
+  return dom.window;
+}
+
+describe('UI layout', () => {
+  test('button columns use fixed grid layout', () => {
+    const window = setupDOM();
+    const cols = window.document.querySelectorAll('.button-col');
+    expect(cols.length).toBeGreaterThan(0);
+    cols.forEach(col => {
+      const style = window.getComputedStyle(col);
+      expect(style.display).toBe('grid');
+      expect(style.gridTemplateColumns).toBe('repeat(4, 1.8rem)');
+    });
+  });
+
+  test('icon buttons have uniform size', () => {
+    const window = setupDOM();
+    const buttons = window.document.querySelectorAll('.icon-button');
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach(btn => {
+      const style = window.getComputedStyle(btn);
+      expect(style.width).toBe('1.8rem');
+      expect(style.height).toBe('1.8rem');
+    });
+  });
+
+  test('input-row children expand evenly', () => {
+    const window = setupDOM();
+    const elems = window.document.querySelectorAll('.input-row textarea, .input-row input[type="number"], .input-row pre');
+    expect(elems.length).toBeGreaterThan(0);
+    elems.forEach(el => {
+      const style = window.getComputedStyle(el);
+      expect(style.flexGrow).toBe('1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- align button columns using CSS grid so missing buttons leave gaps
- reorder buttons to match requested layout: random then save then copy then hide
- fix grid layout vertical alignment by removing default margins on icon buttons
- add Jest DOM test suite for UI alignment of button columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867b366eac88321a1c6b534e6b74992