### PR TITLE
Align buttons vertically and reorder copy

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -55,10 +55,10 @@
           <div class="label-row">
             <label for="divider-input">Divider List</label>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
-              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="divider-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="divider-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
+              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="divider-hide" data-targets="divider-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
             </div>
@@ -73,10 +73,10 @@
           <div class="label-row">
             <label for="base-input">Base Prompt List</label>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
-              <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="base-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="base-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
+              <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="☰" data-off="✖">☰</button>
             </div>
@@ -93,10 +93,10 @@
             <input type="checkbox" id="pos-stack" hidden>
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
-                <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
-                <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="pos-shuffle" hidden>
                 <button type="button" class="toggle-button icon-button random-button" data-target="pos-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+                <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
+                <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="☰" data-off="✖">☰</button>
               </div>
@@ -122,10 +122,10 @@
             <input type="checkbox" id="neg-stack" hidden>
             <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
-                <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
-                <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="neg-shuffle" hidden>
                 <button type="button" class="toggle-button icon-button random-button" data-target="neg-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+                <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
+                <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="☰" data-off="✖">☰</button>
               </div>

--- a/src/style.css
+++ b/src/style.css
@@ -436,8 +436,8 @@ button {
 
 .button-col {
   display: inline-flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   margin-left: 0.25rem;
 }
 .button-col .icon-button {
@@ -448,10 +448,11 @@ button {
   align-items: center;
   padding: 0;
   margin-left: 0;
-  margin-right: 0.25rem;
+  margin-right: 0;
+  margin-bottom: 0.25rem;
 }
 .button-col .icon-button:last-child {
-  margin-right: 0;
+  margin-bottom: 0;
 }
 
 .toggle-button.icon-button {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -5,6 +5,9 @@ if (typeof window !== 'undefined') {
   window.__TEST__ = true;
 }
 
+const fs = require('fs');
+const path = require('path');
+
 const {
   parseInput,
   shuffle,
@@ -362,6 +365,16 @@ describe('UI interactions', () => {
     cb.checked = false;
     cb.dispatchEvent(new Event('change'));
     expect(txt.style.display).toBe('');
+  });
+
+  test('button columns are vertical', () => {
+    document.body.innerHTML = '<div class="button-col"><button></button><button></button></div>';
+    const style = document.createElement('style');
+    style.textContent = fs.readFileSync(path.join(__dirname, '../src/style.css'), 'utf8');
+    document.head.appendChild(style);
+    const col = document.querySelector('.button-col');
+    const computed = window.getComputedStyle(col);
+    expect(computed.flexDirection).toBe('column');
   });
 });
 


### PR DESCRIPTION
## Summary
- reorient button stacks vertically via `.button-col`
- switch copy and dice buttons in each list section
- verify vertical layout with a new Jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c44fc748832198414b6071f010c2