### PR TITLE
Swap copy and random buttons

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -55,10 +55,10 @@
           <div class="label-row">
             <label for="divider-input">Divider List</label>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
-              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="divider-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="divider-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
               <input type="checkbox" id="divider-hide" data-targets="divider-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
             </div>
@@ -73,10 +73,10 @@
           <div class="label-row">
             <label for="base-input">Base Prompt List</label>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
-              <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
               <input type="checkbox" id="base-shuffle" hidden>
               <button type="button" class="toggle-button icon-button random-button" data-target="base-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+              <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
               <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="☰" data-off="✖">☰</button>
             </div>
@@ -93,10 +93,10 @@
             <input type="checkbox" id="pos-stack" hidden>
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
-                <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
-                <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="pos-shuffle" hidden>
                 <button type="button" class="toggle-button icon-button random-button" data-target="pos-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+                <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
+                <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="☰" data-off="✖">☰</button>
               </div>
@@ -122,10 +122,10 @@
             <input type="checkbox" id="neg-stack" hidden>
             <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
-                <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
-                <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <input type="checkbox" id="neg-shuffle" hidden>
                 <button type="button" class="toggle-button icon-button random-button" data-target="neg-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
+                <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
+                <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="☰" data-off="✖">☰</button>
               </div>
@@ -147,8 +147,8 @@
           <div class="label-row">
             <label for="length-input">Length Limit</label>
             <div class="button-col">
-              <button type="button" class="copy-button icon-button" data-target="length-input" title="Copy">&#128203;</button>
               <button type="button" id="length-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <button type="button" class="copy-button icon-button" data-target="length-input" title="Copy">&#128203;</button>
               <input type="checkbox" id="length-hide" data-targets="length-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="length-hide" data-on="☰" data-off="✖">☰</button>
             </div>

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('Button layout', () => {
+  test('random button precedes copy button in all button columns', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const cols = dom.window.document.querySelectorAll('.button-col');
+    cols.forEach(col => {
+      const random = col.querySelector('.random-button');
+      const copy = col.querySelector('.copy-button');
+      if (random && copy) {
+        const nodes = Array.from(col.children);
+        expect(nodes.indexOf(random)).toBeLessThan(nodes.indexOf(copy));
+      }
+    });
+  });
+
+  test('save button precedes copy button in all button columns', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const cols = dom.window.document.querySelectorAll('.button-col');
+    cols.forEach(col => {
+      const save = col.querySelector('.save-button');
+      const copy = col.querySelector('.copy-button');
+      if (save && copy) {
+        const nodes = Array.from(col.children);
+        expect(nodes.indexOf(save)).toBeLessThan(nodes.indexOf(copy));
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- reorder copy and random buttons so the random dice button appears first and the copy button stays consistent across sections
- ensure this layout is consistent via new DOM test
- place save button before copy button on length limit line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867c44fc748832198414b6071f010c2