### PR TITLE
Add lyrics presets

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -169,11 +169,13 @@
           <input type="checkbox" id="lyrics-remove-brackets" hidden>
           <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
           <div class="button-col">
+            <button type="button" id="lyrics-save" class="save-button icon-button" title="Save">&#128190;</button>
             <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
             <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
             <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="☰" data-off="✖">☰</button>
           </div>
         </div>
+        <select id="lyrics-select"></select>
         <div class="input-row">
           <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
         </div>

--- a/src/script.js
+++ b/src/script.js
@@ -16,6 +16,7 @@ let POS_PRESETS = {};
 let LENGTH_PRESETS = {};
 let DIVIDER_PRESETS = {};
 let BASE_PRESETS = {};
+let LYRICS_PRESETS = {};
 
 // Combined lists object used for import/export operations
 let LISTS;
@@ -79,11 +80,13 @@ function loadLists() {
   LENGTH_PRESETS = {};
   DIVIDER_PRESETS = {};
   BASE_PRESETS = {};
+  LYRICS_PRESETS = {};
   const neg = [];
   const pos = [];
   const len = [];
   const divs = [];
   const base = [];
+  const lyrics = [];
 
   if (LISTS.presets && Array.isArray(LISTS.presets)) {
     LISTS.presets.forEach(p => {
@@ -102,6 +105,9 @@ function loadLists() {
       } else if (p.type === 'base') {
         BASE_PRESETS[p.id] = p.items || [];
         base.push(p);
+      } else if (p.type === 'lyrics') {
+        LYRICS_PRESETS[p.id] = p.items || [];
+        lyrics.push(p);
       }
     });
   }
@@ -120,6 +126,9 @@ function loadLists() {
 
   const baseSelect = document.getElementById('base-select');
   if (baseSelect) populateSelect(baseSelect, base);
+
+  const lyricsSelect = document.getElementById('lyrics-select');
+  if (lyricsSelect) populateSelect(lyricsSelect, lyrics);
 
   // Uncomment the following lines for a quick summary when debugging
   // console.log('Lists loaded:', {
@@ -523,6 +532,8 @@ function applyPreset(selectEl, inputEl, presetsOrType) {
       presets = DIVIDER_PRESETS;
     } else if (presetsOrType === 'base') {
       presets = BASE_PRESETS;
+    } else if (presetsOrType === 'lyrics') {
+      presets = LYRICS_PRESETS;
     } else {
       presets = {};
     }
@@ -889,7 +900,8 @@ function saveList(type) {
     negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
     positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
     length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-    divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS }
+    divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
+    lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
   };
   const cfg = map[type];
   if (!cfg) return;
@@ -898,7 +910,14 @@ function saveList(type) {
   if (!sel || !inp) return;
   const name = prompt('Enter list name', sel.value);
   if (!name) return;
-  const items = type === 'divider' ? parseDividerInput(inp.value) : parseInput(inp.value);
+  let items;
+  if (type === 'divider') {
+    items = parseDividerInput(inp.value);
+  } else if (type === 'lyrics') {
+    items = [inp.value];
+  } else {
+    items = parseInput(inp.value);
+  }
   let preset = LISTS.presets.find(p => p.id === name && p.type === type);
   if (!preset) {
     preset = { id: name, title: name, type, items };
@@ -949,12 +968,18 @@ function initializeUI() {
     document.getElementById('base-input'),
     'base'
   );
+  applyPreset(
+    document.getElementById('lyrics-select'),
+    document.getElementById('lyrics-input'),
+    'lyrics'
+  );
 
   setupPresetListener('neg-select', 'neg-input', 'negative');
   setupPresetListener('pos-select', 'pos-input', 'positive');
   setupPresetListener('length-select', 'length-input', 'length');
   setupPresetListener('divider-select', 'divider-input', 'divider');
   setupPresetListener('base-select', 'base-input', 'base');
+  setupPresetListener('lyrics-select', 'lyrics-input', 'lyrics');
   document.getElementById('generate').addEventListener('click', generate);
 
   setupToggleButtons();
@@ -1012,6 +1037,8 @@ function initializeUI() {
   if (lenSave) lenSave.addEventListener('click', () => saveList('length'));
   const divSave = document.getElementById('divider-save');
   if (divSave) divSave.addEventListener('click', () => saveList('divider'));
+  const lyricsSave = document.getElementById('lyrics-save');
+  if (lyricsSave) lyricsSave.addEventListener('click', () => saveList('lyrics'));
 }
 
 // Initialize UI when DOM is ready

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -419,6 +419,21 @@ describe('List persistence', () => {
     expect(opt).not.toBeNull();
   });
 
+  test('saveList works for lyrics', () => {
+    document.body.innerHTML = `
+      <select id="lyrics-select"></select>
+      <textarea id="lyrics-input">line1\nline2</textarea>
+    `;
+    importLists({ presets: [] });
+    global.prompt = jest.fn().mockReturnValue('ly1');
+    saveList('lyrics');
+    const data = JSON.parse(exportLists());
+    const preset = data.presets.find(p => p.id === 'ly1' && p.type === 'lyrics');
+    expect(preset.items).toEqual(['line1\nline2']);
+    const opt = document.querySelector('#lyrics-select option[value="ly1"]');
+    expect(opt).not.toBeNull();
+  });
+
   test('sequential save and reload', () => {
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -431,9 +446,11 @@ describe('List persistence', () => {
       <input id="length-input">
       <select id="divider-select"></select>
       <textarea id="divider-input"></textarea>
+      <select id="lyrics-select"></select>
+      <textarea id="lyrics-input"></textarea>
     `;
     importLists({ presets: [] });
-    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1'];
+    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1', 'ly1'];
     global.prompt = jest.fn(() => names.shift());
     document.getElementById('pos-input').value = 'x';
     saveList('positive');
@@ -447,9 +464,11 @@ describe('List persistence', () => {
     saveList('length');
     document.getElementById('divider-input').value = 'foo';
     saveList('divider');
+    document.getElementById('lyrics-input').value = 'lyric';
+    saveList('lyrics');
 
     const exported = JSON.parse(exportLists());
-    expect(exported.presets.length).toBe(6);
+    expect(exported.presets.length).toBe(7);
 
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -462,6 +481,8 @@ describe('List persistence', () => {
       <input id="length-input">
       <select id="divider-select"></select>
       <textarea id="divider-input"></textarea>
+      <select id="lyrics-select"></select>
+      <textarea id="lyrics-input"></textarea>
     `;
     importLists(exported);
     const posSelVals = Array.from(document.querySelectorAll('#pos-select option')).map(o => o.value);
@@ -486,7 +507,12 @@ describe('List persistence', () => {
       const divInput = document.getElementById('divider-input');
       divSelect.value = 'd1';
       applyPreset(divSelect, divInput, 'divider');
-    expect(divInput.value).toBe('foo');
+      expect(divInput.value).toBe('foo');
+      const lyrSelect = document.getElementById('lyrics-select');
+      const lyrInput = document.getElementById('lyrics-input');
+      lyrSelect.value = 'ly1';
+      applyPreset(lyrSelect, lyrInput, 'lyrics');
+      expect(lyrInput.value).toBe('lyric');
   });
 
   test('importLists additive merges lists', () => {


### PR DESCRIPTION
## Summary
- allow saving/loading lyrics presets
- add lyrics preset dropdown and button to UI
- test lyrics list functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c9957b2883218864f618842824b8