### PR TITLE
Implement state object and serialization

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -1,11 +1,7 @@
 (function (global) {
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  let NEG_PRESETS = {};
-  let POS_PRESETS = {};
-  let LENGTH_PRESETS = {};
-  let DIVIDER_PRESETS = {};
-  let BASE_PRESETS = {};
-  let LYRICS_PRESETS = {};
+  const stateModule = global.promptState || (typeof require !== 'undefined' && require('./state'));
+  const { state } = stateModule;
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -43,12 +39,12 @@
   }
 
   function loadLists() {
-    NEG_PRESETS = {};
-    POS_PRESETS = {};
-    LENGTH_PRESETS = {};
-    DIVIDER_PRESETS = {};
-    BASE_PRESETS = {};
-    LYRICS_PRESETS = {};
+    state.presets.negative = {};
+    state.presets.positive = {};
+    state.presets.length = {};
+    state.presets.divider = {};
+    state.presets.base = {};
+    state.presets.lyrics = {};
     const neg = [];
     const pos = [];
     const len = [];
@@ -58,22 +54,22 @@
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
-          NEG_PRESETS[p.id] = p.items || [];
+          state.presets.negative[p.id] = p.items || [];
           neg.push(p);
         } else if (p.type === 'positive') {
-          POS_PRESETS[p.id] = p.items || [];
+          state.presets.positive[p.id] = p.items || [];
           pos.push(p);
         } else if (p.type === 'length') {
-          LENGTH_PRESETS[p.id] = p.items || [];
+          state.presets.length[p.id] = p.items || [];
           len.push(p);
         } else if (p.type === 'divider') {
-          DIVIDER_PRESETS[p.id] = p.items || [];
+          state.presets.divider[p.id] = p.items || [];
           divs.push(p);
         } else if (p.type === 'base') {
-          BASE_PRESETS[p.id] = p.items || [];
+          state.presets.base[p.id] = p.items || [];
           base.push(p);
         } else if (p.type === 'lyrics') {
-          LYRICS_PRESETS[p.id] = p.items || [];
+          state.presets.lyrics[p.id] = p.items || [];
           lyrics.push(p);
         }
       });
@@ -157,12 +153,12 @@
 
   function saveList(type) {
     const map = {
-      base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
-      negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
-      positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-      length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-      divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      base: { select: 'base-select', input: 'base-input', store: state.presets.base },
+      negative: { select: 'neg-select', input: 'neg-input', store: state.presets.negative },
+      positive: { select: 'pos-select', input: 'pos-input', store: state.presets.positive },
+      length: { select: 'length-select', input: 'length-input', store: state.presets.length },
+      divider: { select: 'divider-select', input: 'divider-input', store: state.presets.divider },
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: state.presets.lyrics }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -195,12 +191,12 @@
   }
 
   const api = {
-    get NEG_PRESETS() { return NEG_PRESETS; },
-    get POS_PRESETS() { return POS_PRESETS; },
-    get LENGTH_PRESETS() { return LENGTH_PRESETS; },
-    get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
-    get BASE_PRESETS() { return BASE_PRESETS; },
-    get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get NEG_PRESETS() { return state.presets.negative; },
+    get POS_PRESETS() { return state.presets.positive; },
+    get LENGTH_PRESETS() { return state.presets.length; },
+    get DIVIDER_PRESETS() { return state.presets.divider; },
+    get BASE_PRESETS() { return state.presets.base; },
+    get LYRICS_PRESETS() { return state.presets.lyrics; },
     loadLists,
     exportLists,
     importLists,

--- a/src/script.js
+++ b/src/script.js
@@ -2,6 +2,7 @@
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
   const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const ui = global.uiControls || (typeof require !== 'undefined' && require('./uiControls'));
+  const stateModule = global.promptState || (typeof require !== 'undefined' && require('./state'));
 
   if (typeof document !== 'undefined' && !(typeof window !== 'undefined' && window.__TEST__)) {
     const init = ui.initializeUI;
@@ -13,6 +14,6 @@
   }
 
   if (typeof module !== 'undefined') {
-    module.exports = { ...utils, ...lists, ...ui };
+    module.exports = { ...utils, ...lists, ...ui, ...stateModule };
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,46 @@
+(function (global) {
+  const state = {
+    presets: {
+      negative: {},
+      positive: {},
+      length: {},
+      divider: {},
+      base: {},
+      lyrics: {}
+    },
+    shuffleFlags: {
+      base: false,
+      negative: false,
+      positive: false,
+      dividers: false
+    },
+    seed: null
+  };
+
+  function exportState() {
+    return JSON.stringify(state, null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj || typeof obj !== 'object') return;
+    if (obj.presets && typeof obj.presets === 'object') {
+      Object.keys(state.presets).forEach(key => {
+        state.presets[key] = { ...(obj.presets[key] || {}) };
+      });
+    }
+    if (obj.shuffleFlags && typeof obj.shuffleFlags === 'object') {
+      Object.keys(state.shuffleFlags).forEach(key => {
+        state.shuffleFlags[key] = !!obj.shuffleFlags[key];
+      });
+    }
+    if ('seed' in obj) state.seed = obj.seed;
+  }
+
+  const api = { state, exportState, importState };
+
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.promptState = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -554,3 +554,22 @@ describe('List persistence', () => {
     expect(lists.length).toBe(2);
   });
 });
+
+const stateModule = require('../src/state');
+const { state, exportState, importState } = stateModule;
+
+describe('State persistence', () => {
+  test('exportState and importState round trip', () => {
+    state.presets.positive = { a: ['1'] };
+    state.shuffleFlags.base = true;
+    state.seed = 42;
+    const json = exportState();
+    state.presets.positive = {};
+    state.shuffleFlags.base = false;
+    state.seed = null;
+    importState(JSON.parse(json));
+    expect(state.presets.positive).toEqual({ a: ['1'] });
+    expect(state.shuffleFlags.base).toBe(true);
+    expect(state.seed).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `state` module with export/import helpers
- refactor `listManager` to use `state` for storing presets
- expose `state` via main script exports
- add tests for state persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d827954c832199753e76e8b65b64