### PR TITLE
Introduce centralized state management

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -1,11 +1,8 @@
 (function (global) {
-  const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  let NEG_PRESETS = {};
-  let POS_PRESETS = {};
-  let LENGTH_PRESETS = {};
-  let DIVIDER_PRESETS = {};
-  let BASE_PRESETS = {};
-  let LYRICS_PRESETS = {};
+  const utils =
+    global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
+  const appState = global.appState || (typeof require !== 'undefined' && require('./state'));
+  const state = appState.state;
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -43,12 +40,12 @@
   }
 
   function loadLists() {
-    NEG_PRESETS = {};
-    POS_PRESETS = {};
-    LENGTH_PRESETS = {};
-    DIVIDER_PRESETS = {};
-    BASE_PRESETS = {};
-    LYRICS_PRESETS = {};
+    state.NEG_PRESETS = {};
+    state.POS_PRESETS = {};
+    state.LENGTH_PRESETS = {};
+    state.DIVIDER_PRESETS = {};
+    state.BASE_PRESETS = {};
+    state.LYRICS_PRESETS = {};
     const neg = [];
     const pos = [];
     const len = [];
@@ -58,22 +55,22 @@
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
-          NEG_PRESETS[p.id] = p.items || [];
+          state.NEG_PRESETS[p.id] = p.items || [];
           neg.push(p);
         } else if (p.type === 'positive') {
-          POS_PRESETS[p.id] = p.items || [];
+          state.POS_PRESETS[p.id] = p.items || [];
           pos.push(p);
         } else if (p.type === 'length') {
-          LENGTH_PRESETS[p.id] = p.items || [];
+          state.LENGTH_PRESETS[p.id] = p.items || [];
           len.push(p);
         } else if (p.type === 'divider') {
-          DIVIDER_PRESETS[p.id] = p.items || [];
+          state.DIVIDER_PRESETS[p.id] = p.items || [];
           divs.push(p);
         } else if (p.type === 'base') {
-          BASE_PRESETS[p.id] = p.items || [];
+          state.BASE_PRESETS[p.id] = p.items || [];
           base.push(p);
         } else if (p.type === 'lyrics') {
-          LYRICS_PRESETS[p.id] = p.items || [];
+          state.LYRICS_PRESETS[p.id] = p.items || [];
           lyrics.push(p);
         }
       });
@@ -157,12 +154,12 @@
 
   function saveList(type) {
     const map = {
-      base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
-      negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
-      positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-      length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-      divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      base: { select: 'base-select', input: 'base-input', store: state.BASE_PRESETS },
+      negative: { select: 'neg-select', input: 'neg-input', store: state.NEG_PRESETS },
+      positive: { select: 'pos-select', input: 'pos-input', store: state.POS_PRESETS },
+      length: { select: 'length-select', input: 'length-input', store: state.LENGTH_PRESETS },
+      divider: { select: 'divider-select', input: 'divider-input', store: state.DIVIDER_PRESETS },
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: state.LYRICS_PRESETS }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -195,12 +192,24 @@
   }
 
   const api = {
-    get NEG_PRESETS() { return NEG_PRESETS; },
-    get POS_PRESETS() { return POS_PRESETS; },
-    get LENGTH_PRESETS() { return LENGTH_PRESETS; },
-    get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
-    get BASE_PRESETS() { return BASE_PRESETS; },
-    get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get NEG_PRESETS() {
+      return state.NEG_PRESETS;
+    },
+    get POS_PRESETS() {
+      return state.POS_PRESETS;
+    },
+    get LENGTH_PRESETS() {
+      return state.LENGTH_PRESETS;
+    },
+    get DIVIDER_PRESETS() {
+      return state.DIVIDER_PRESETS;
+    },
+    get BASE_PRESETS() {
+      return state.BASE_PRESETS;
+    },
+    get LYRICS_PRESETS() {
+      return state.LYRICS_PRESETS;
+    },
     loadLists,
     exportLists,
     importLists,

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,47 @@
+(function (global) {
+  const state = {
+    NEG_PRESETS: {},
+    POS_PRESETS: {},
+    LENGTH_PRESETS: {},
+    DIVIDER_PRESETS: {},
+    BASE_PRESETS: {},
+    LYRICS_PRESETS: {},
+    shuffleBase: false,
+    shufflePos: false,
+    shuffleNeg: false,
+    seed: null
+  };
+
+  function exportState() {
+    return JSON.stringify(state, null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj) return;
+    if (typeof obj === 'string') {
+      try {
+        obj = JSON.parse(obj);
+      } catch (err) {
+        return;
+      }
+    }
+    if (typeof obj !== 'object') return;
+    Object.keys(state).forEach(key => {
+      if (obj[key] !== undefined) {
+        if (state[key] && typeof state[key] === 'object') {
+          state[key] = JSON.parse(JSON.stringify(obj[key]));
+        } else {
+          state[key] = obj[key];
+        }
+      }
+    });
+  }
+
+  const api = { state, exportState, importState };
+
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.appState = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -8,6 +8,7 @@ if (typeof window !== 'undefined') {
 const utils = require('../src/promptUtils');
 const lists = require('../src/listManager');
 const ui = require('../src/uiControls');
+const stateModule = require('../src/state');
 
 const {
   parseInput,
@@ -552,5 +553,23 @@ describe('List persistence', () => {
     const data = JSON.parse(exportLists());
     const lists = data.presets.filter(p => p.id === 'a' && p.type === 'positive');
     expect(lists.length).toBe(2);
+  });
+});
+
+describe('State persistence', () => {
+  const { state, exportState, importState } = stateModule;
+
+  test('exportState and importState round trip', () => {
+    state.NEG_PRESETS = { a: ['x'] };
+    state.shuffleBase = true;
+    state.seed = 42;
+    const json = exportState();
+    state.NEG_PRESETS = {};
+    state.shuffleBase = false;
+    state.seed = null;
+    importState(json);
+    expect(state.NEG_PRESETS).toEqual({ a: ['x'] });
+    expect(state.shuffleBase).toBe(true);
+    expect(state.seed).toBe(42);
   });
 });


### PR DESCRIPTION
## Summary
- add new `state` module to hold preset maps and shuffle flags
- refactor list manager to read/write presets from `state`
- provide helpers to export/import app state
- verify round‐trip of state in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d827954c832199753e76e8b65b64