### PR TITLE
Introduce centralized state management

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -1,11 +1,7 @@
 (function (global) {
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  let NEG_PRESETS = {};
-  let POS_PRESETS = {};
-  let LENGTH_PRESETS = {};
-  let DIVIDER_PRESETS = {};
-  let BASE_PRESETS = {};
-  let LYRICS_PRESETS = {};
+  const appState = global.appState || (typeof require !== 'undefined' && require('./state'));
+  const STATE = appState.state;
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -43,12 +39,12 @@
   }
 
   function loadLists() {
-    NEG_PRESETS = {};
-    POS_PRESETS = {};
-    LENGTH_PRESETS = {};
-    DIVIDER_PRESETS = {};
-    BASE_PRESETS = {};
-    LYRICS_PRESETS = {};
+    STATE.presets.negative = {};
+    STATE.presets.positive = {};
+    STATE.presets.length = {};
+    STATE.presets.divider = {};
+    STATE.presets.base = {};
+    STATE.presets.lyrics = {};
     const neg = [];
     const pos = [];
     const len = [];
@@ -58,22 +54,22 @@
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
-          NEG_PRESETS[p.id] = p.items || [];
+          STATE.presets.negative[p.id] = p.items || [];
           neg.push(p);
         } else if (p.type === 'positive') {
-          POS_PRESETS[p.id] = p.items || [];
+          STATE.presets.positive[p.id] = p.items || [];
           pos.push(p);
         } else if (p.type === 'length') {
-          LENGTH_PRESETS[p.id] = p.items || [];
+          STATE.presets.length[p.id] = p.items || [];
           len.push(p);
         } else if (p.type === 'divider') {
-          DIVIDER_PRESETS[p.id] = p.items || [];
+          STATE.presets.divider[p.id] = p.items || [];
           divs.push(p);
         } else if (p.type === 'base') {
-          BASE_PRESETS[p.id] = p.items || [];
+          STATE.presets.base[p.id] = p.items || [];
           base.push(p);
         } else if (p.type === 'lyrics') {
-          LYRICS_PRESETS[p.id] = p.items || [];
+          STATE.presets.lyrics[p.id] = p.items || [];
           lyrics.push(p);
         }
       });
@@ -157,12 +153,12 @@
 
   function saveList(type) {
     const map = {
-      base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
-      negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
-      positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-      length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-      divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      base: { select: 'base-select', input: 'base-input', store: STATE.presets.base },
+      negative: { select: 'neg-select', input: 'neg-input', store: STATE.presets.negative },
+      positive: { select: 'pos-select', input: 'pos-input', store: STATE.presets.positive },
+      length: { select: 'length-select', input: 'length-input', store: STATE.presets.length },
+      divider: { select: 'divider-select', input: 'divider-input', store: STATE.presets.divider },
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: STATE.presets.lyrics }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -195,12 +191,12 @@
   }
 
   const api = {
-    get NEG_PRESETS() { return NEG_PRESETS; },
-    get POS_PRESETS() { return POS_PRESETS; },
-    get LENGTH_PRESETS() { return LENGTH_PRESETS; },
-    get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
-    get BASE_PRESETS() { return BASE_PRESETS; },
-    get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get NEG_PRESETS() { return STATE.presets.negative; },
+    get POS_PRESETS() { return STATE.presets.positive; },
+    get LENGTH_PRESETS() { return STATE.presets.length; },
+    get DIVIDER_PRESETS() { return STATE.presets.divider; },
+    get BASE_PRESETS() { return STATE.presets.base; },
+    get LYRICS_PRESETS() { return STATE.presets.lyrics; },
     loadLists,
     exportLists,
     importLists,

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,52 @@
+(function (global) {
+  const state = {
+    presets: {
+      negative: {},
+      positive: {},
+      length: {},
+      divider: {},
+      base: {},
+      lyrics: {}
+    },
+    shuffle: {
+      base: false,
+      positive: false,
+      negative: false,
+      divider: false
+    },
+    seed: null
+  };
+
+  function exportState() {
+    return JSON.stringify(state, null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj) return;
+    const data = typeof obj === 'string' ? JSON.parse(obj) : obj;
+    if (data.presets) {
+      state.presets.negative = data.presets.negative || {};
+      state.presets.positive = data.presets.positive || {};
+      state.presets.length = data.presets.length || {};
+      state.presets.divider = data.presets.divider || {};
+      state.presets.base = data.presets.base || {};
+      state.presets.lyrics = data.presets.lyrics || {};
+    }
+    if (data.shuffle) {
+      state.shuffle.base = !!data.shuffle.base;
+      state.shuffle.positive = !!data.shuffle.positive;
+      state.shuffle.negative = !!data.shuffle.negative;
+      state.shuffle.divider = !!data.shuffle.divider;
+    }
+    if (Object.prototype.hasOwnProperty.call(data, 'seed')) {
+      state.seed = data.seed;
+    }
+  }
+
+  const api = { state, exportState, importState };
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.appState = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -7,6 +7,7 @@ if (typeof window !== 'undefined') {
 
 const utils = require('../src/promptUtils');
 const lists = require('../src/listManager');
+const stateModule = require('../src/state');
 const ui = require('../src/uiControls');
 
 const {
@@ -20,6 +21,7 @@ const {
 } = utils;
 
 const { exportLists, importLists, saveList } = lists;
+const { state, exportState, importState } = stateModule;
 
 const { setupShuffleAll, setupStackControls, setupHideToggles, applyPreset } = ui;
 
@@ -552,5 +554,27 @@ describe('List persistence', () => {
     const data = JSON.parse(exportLists());
     const lists = data.presets.filter(p => p.id === 'a' && p.type === 'positive');
     expect(lists.length).toBe(2);
+  });
+
+  test('exportState and importState round trip', () => {
+    state.shuffle.base = true;
+    state.shuffle.positive = true;
+    state.seed = 42;
+    state.presets.negative.test = ['x'];
+    const json = exportState();
+    state.shuffle.base = false;
+    state.shuffle.positive = false;
+    state.seed = null;
+    state.presets.negative = {};
+    importState(JSON.parse(json));
+    expect(exportState()).toBe(json);
+  });
+
+  test('importLists populates state presets and options', () => {
+    document.body.innerHTML = '<select id="pos-select"></select>';
+    importLists({ presets: [{ id: 'p1', title: 'p1', type: 'positive', items: ['a'] }] });
+    expect(state.presets.positive.p1).toEqual(['a']);
+    const opt = document.querySelector('#pos-select option[value="p1"]');
+    expect(opt).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add new `state` module to hold preset dictionaries, shuffle flags, and seed
- refactor list manager to read/write presets through `state`
- provide JSON serialization helpers for state
- verify round‑trip state serialization and list loading in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867da628df48321a6f91a7ee15ab1a9