### PR TITLE
Introduce centralized state object

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -1,11 +1,9 @@
 (function (global) {
-  const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  let NEG_PRESETS = {};
-  let POS_PRESETS = {};
-  let LENGTH_PRESETS = {};
-  let DIVIDER_PRESETS = {};
-  let BASE_PRESETS = {};
-  let LYRICS_PRESETS = {};
+  const utils =
+    global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
+  const stateUtil =
+    global.stateUtils || (typeof require !== 'undefined' && require('./state'));
+  const state = stateUtil.state;
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -43,12 +41,12 @@
   }
 
   function loadLists() {
-    NEG_PRESETS = {};
-    POS_PRESETS = {};
-    LENGTH_PRESETS = {};
-    DIVIDER_PRESETS = {};
-    BASE_PRESETS = {};
-    LYRICS_PRESETS = {};
+    state.presets.negative = {};
+    state.presets.positive = {};
+    state.presets.length = {};
+    state.presets.divider = {};
+    state.presets.base = {};
+    state.presets.lyrics = {};
     const neg = [];
     const pos = [];
     const len = [];
@@ -58,22 +56,22 @@
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
-          NEG_PRESETS[p.id] = p.items || [];
+          state.presets.negative[p.id] = p.items || [];
           neg.push(p);
         } else if (p.type === 'positive') {
-          POS_PRESETS[p.id] = p.items || [];
+          state.presets.positive[p.id] = p.items || [];
           pos.push(p);
         } else if (p.type === 'length') {
-          LENGTH_PRESETS[p.id] = p.items || [];
+          state.presets.length[p.id] = p.items || [];
           len.push(p);
         } else if (p.type === 'divider') {
-          DIVIDER_PRESETS[p.id] = p.items || [];
+          state.presets.divider[p.id] = p.items || [];
           divs.push(p);
         } else if (p.type === 'base') {
-          BASE_PRESETS[p.id] = p.items || [];
+          state.presets.base[p.id] = p.items || [];
           base.push(p);
         } else if (p.type === 'lyrics') {
-          LYRICS_PRESETS[p.id] = p.items || [];
+          state.presets.lyrics[p.id] = p.items || [];
           lyrics.push(p);
         }
       });
@@ -157,12 +155,36 @@
 
   function saveList(type) {
     const map = {
-      base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
-      negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
-      positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-      length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-      divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      base: {
+        select: 'base-select',
+        input: 'base-input',
+        store: state.presets.base
+      },
+      negative: {
+        select: 'neg-select',
+        input: 'neg-input',
+        store: state.presets.negative
+      },
+      positive: {
+        select: 'pos-select',
+        input: 'pos-input',
+        store: state.presets.positive
+      },
+      length: {
+        select: 'length-select',
+        input: 'length-input',
+        store: state.presets.length
+      },
+      divider: {
+        select: 'divider-select',
+        input: 'divider-input',
+        store: state.presets.divider
+      },
+      lyrics: {
+        select: 'lyrics-select',
+        input: 'lyrics-input',
+        store: state.presets.lyrics
+      }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -195,12 +217,24 @@
   }
 
   const api = {
-    get NEG_PRESETS() { return NEG_PRESETS; },
-    get POS_PRESETS() { return POS_PRESETS; },
-    get LENGTH_PRESETS() { return LENGTH_PRESETS; },
-    get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
-    get BASE_PRESETS() { return BASE_PRESETS; },
-    get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get NEG_PRESETS() {
+      return state.presets.negative;
+    },
+    get POS_PRESETS() {
+      return state.presets.positive;
+    },
+    get LENGTH_PRESETS() {
+      return state.presets.length;
+    },
+    get DIVIDER_PRESETS() {
+      return state.presets.divider;
+    },
+    get BASE_PRESETS() {
+      return state.presets.base;
+    },
+    get LYRICS_PRESETS() {
+      return state.presets.lyrics;
+    },
     loadLists,
     exportLists,
     importLists,

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,44 @@
+(function (global) {
+  const state = {
+    presets: {
+      negative: {},
+      positive: {},
+      length: {},
+      divider: {},
+      base: {},
+      lyrics: {}
+    },
+    shuffleFlags: {},
+    seed: null
+  };
+
+  function exportState() {
+    return JSON.stringify(state, null, 2);
+  }
+
+  function importState(obj) {
+    const data = typeof obj === 'string' ? JSON.parse(obj) : obj;
+    if (!data || typeof data !== 'object') return;
+    if (data.presets && typeof data.presets === 'object') {
+      state.presets = {
+        negative: data.presets.negative || {},
+        positive: data.presets.positive || {},
+        length: data.presets.length || {},
+        divider: data.presets.divider || {},
+        base: data.presets.base || {},
+        lyrics: data.presets.lyrics || {}
+      };
+    }
+    state.shuffleFlags = data.shuffleFlags || {};
+    state.seed = data.seed !== undefined ? data.seed : null;
+  }
+
+  const api = { state, exportState, importState };
+
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.state = state;
+    global.stateUtils = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -1,6 +1,10 @@
 (function (global) {
-  const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
+  const utils =
+    global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
+  const lists =
+    global.listManager || (typeof require !== 'undefined' && require('./listManager'));
+  const stateUtil =
+    global.stateUtils || (typeof require !== 'undefined' && require('./state'));
 
   function applyPreset(selectEl, inputEl, presetsOrType) {
     let presets = presetsOrType;
@@ -49,10 +53,15 @@
     const posStackSize = parseInt(document.getElementById('pos-stack-size')?.value || '1', 10);
     const includePosForNeg = document.getElementById('neg-include-pos').checked;
     const shuffleNeg = document.getElementById('neg-shuffle').checked;
+
+    stateUtil.state.shuffleFlags.base = shuffleBase;
+    stateUtil.state.shuffleFlags.positive = shufflePos;
+    stateUtil.state.shuffleFlags.negative = shuffleNeg;
     const negStackOn = document.getElementById('neg-stack').checked;
     const negStackSize = parseInt(document.getElementById('neg-stack-size')?.value || '1', 10);
     const dividerMods = utils.parseDividerInput(document.getElementById('divider-input')?.value || '');
     const shuffleDividers = document.getElementById('divider-shuffle')?.checked;
+    stateUtil.state.shuffleFlags.divider = shuffleDividers;
     const lengthSelect = document.getElementById('length-select');
     const lengthInput = document.getElementById('length-input');
     let limit = parseInt(lengthInput.value, 10);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -8,6 +8,7 @@ if (typeof window !== 'undefined') {
 const utils = require('../src/promptUtils');
 const lists = require('../src/listManager');
 const ui = require('../src/uiControls');
+const stateUtil = require('../src/state');
 
 const {
   parseInput,
@@ -552,5 +553,24 @@ describe('List persistence', () => {
     const data = JSON.parse(exportLists());
     const lists = data.presets.filter(p => p.id === 'a' && p.type === 'positive');
     expect(lists.length).toBe(2);
+  });
+
+  test('state export and import round trip', () => {
+    stateUtil.importState({
+      presets: { positive: { foo: ['x'] } },
+      shuffleFlags: { base: true },
+      seed: 42
+    });
+    const json = stateUtil.exportState();
+    stateUtil.importState({ presets: {} });
+    stateUtil.importState(JSON.parse(json));
+    expect(stateUtil.state.presets.positive.foo).toEqual(['x']);
+    expect(stateUtil.state.shuffleFlags.base).toBe(true);
+    expect(stateUtil.state.seed).toBe(42);
+  });
+
+  test('importLists populates state presets', () => {
+    importLists({ presets: [{ id: 't', title: 't', type: 'negative', items: ['n'] }] });
+    expect(stateUtil.state.presets.negative.t).toEqual(['n']);
   });
 });


### PR DESCRIPTION
## Summary
- add `state` module with `exportState`/`importState`
- refactor list manager to store presets in state
- record shuffle flags via state in UI controls
- test state serialization and list loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867da628df48321a6f91a7ee15ab1a9