### PR TITLE
Add shared state module with serialization

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -1,11 +1,9 @@
 (function (global) {
-  const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  let NEG_PRESETS = {};
-  let POS_PRESETS = {};
-  let LENGTH_PRESETS = {};
-  let DIVIDER_PRESETS = {};
-  let BASE_PRESETS = {};
-  let LYRICS_PRESETS = {};
+  const utils =
+    global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
+  const stateMod =
+    global.stateManager || (typeof require !== 'undefined' && require('./state'));
+  const state = stateMod.state;
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -43,12 +41,12 @@
   }
 
   function loadLists() {
-    NEG_PRESETS = {};
-    POS_PRESETS = {};
-    LENGTH_PRESETS = {};
-    DIVIDER_PRESETS = {};
-    BASE_PRESETS = {};
-    LYRICS_PRESETS = {};
+    state.presets.negative = {};
+    state.presets.positive = {};
+    state.presets.length = {};
+    state.presets.divider = {};
+    state.presets.base = {};
+    state.presets.lyrics = {};
     const neg = [];
     const pos = [];
     const len = [];
@@ -58,22 +56,22 @@
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
-          NEG_PRESETS[p.id] = p.items || [];
+          state.presets.negative[p.id] = p.items || [];
           neg.push(p);
         } else if (p.type === 'positive') {
-          POS_PRESETS[p.id] = p.items || [];
+          state.presets.positive[p.id] = p.items || [];
           pos.push(p);
         } else if (p.type === 'length') {
-          LENGTH_PRESETS[p.id] = p.items || [];
+          state.presets.length[p.id] = p.items || [];
           len.push(p);
         } else if (p.type === 'divider') {
-          DIVIDER_PRESETS[p.id] = p.items || [];
+          state.presets.divider[p.id] = p.items || [];
           divs.push(p);
         } else if (p.type === 'base') {
-          BASE_PRESETS[p.id] = p.items || [];
+          state.presets.base[p.id] = p.items || [];
           base.push(p);
         } else if (p.type === 'lyrics') {
-          LYRICS_PRESETS[p.id] = p.items || [];
+          state.presets.lyrics[p.id] = p.items || [];
           lyrics.push(p);
         }
       });
@@ -157,12 +155,12 @@
 
   function saveList(type) {
     const map = {
-      base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
-      negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
-      positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
-      length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
-      divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      base: { select: 'base-select', input: 'base-input', store: state.presets.base },
+      negative: { select: 'neg-select', input: 'neg-input', store: state.presets.negative },
+      positive: { select: 'pos-select', input: 'pos-input', store: state.presets.positive },
+      length: { select: 'length-select', input: 'length-input', store: state.presets.length },
+      divider: { select: 'divider-select', input: 'divider-input', store: state.presets.divider },
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: state.presets.lyrics }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -195,12 +193,24 @@
   }
 
   const api = {
-    get NEG_PRESETS() { return NEG_PRESETS; },
-    get POS_PRESETS() { return POS_PRESETS; },
-    get LENGTH_PRESETS() { return LENGTH_PRESETS; },
-    get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
-    get BASE_PRESETS() { return BASE_PRESETS; },
-    get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get NEG_PRESETS() {
+      return state.presets.negative;
+    },
+    get POS_PRESETS() {
+      return state.presets.positive;
+    },
+    get LENGTH_PRESETS() {
+      return state.presets.length;
+    },
+    get DIVIDER_PRESETS() {
+      return state.presets.divider;
+    },
+    get BASE_PRESETS() {
+      return state.presets.base;
+    },
+    get LYRICS_PRESETS() {
+      return state.presets.lyrics;
+    },
     loadLists,
     exportLists,
     importLists,

--- a/src/script.js
+++ b/src/script.js
@@ -1,7 +1,10 @@
 (function (global) {
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
-  const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
+  const lists =
+    global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const ui = global.uiControls || (typeof require !== 'undefined' && require('./uiControls'));
+  const state =
+    global.stateManager || (typeof require !== 'undefined' && require('./state'));
 
   if (typeof document !== 'undefined' && !(typeof window !== 'undefined' && window.__TEST__)) {
     const init = ui.initializeUI;
@@ -13,6 +16,6 @@
   }
 
   if (typeof module !== 'undefined') {
-    module.exports = { ...utils, ...lists, ...ui };
+    module.exports = { ...utils, ...lists, ...ui, ...state };
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,52 @@
+(function (global) {
+  const state = {
+    presets: {
+      negative: {},
+      positive: {},
+      length: {},
+      divider: {},
+      base: {},
+      lyrics: {}
+    },
+    shuffle: {
+      base: false,
+      positive: false,
+      negative: false,
+      dividers: false
+    },
+    seed: null
+  };
+
+  function exportState() {
+    return JSON.stringify(state, null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj || typeof obj !== 'object') return;
+    if (obj.presets && typeof obj.presets === 'object') {
+      const p = obj.presets;
+      state.presets.negative = p.negative || {};
+      state.presets.positive = p.positive || {};
+      state.presets.length = p.length || {};
+      state.presets.divider = p.divider || {};
+      state.presets.base = p.base || {};
+      state.presets.lyrics = p.lyrics || {};
+    }
+    if (obj.shuffle && typeof obj.shuffle === 'object') {
+      const s = obj.shuffle;
+      state.shuffle.base = !!s.base;
+      state.shuffle.positive = !!s.positive;
+      state.shuffle.negative = !!s.negative;
+      state.shuffle.dividers = !!s.dividers;
+    }
+    if (Object.prototype.hasOwnProperty.call(obj, 'seed')) {
+      state.seed = obj.seed;
+    }
+  }
+
+  if (typeof module !== 'undefined') {
+    module.exports = { state, exportState, importState };
+  } else {
+    global.stateManager = { state, exportState, importState };
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -553,4 +553,28 @@ describe('List persistence', () => {
     const lists = data.presets.filter(p => p.id === 'a' && p.type === 'positive');
     expect(lists.length).toBe(2);
   });
+
+  test('loadLists populates preset maps', () => {
+    document.body.innerHTML = `<select id="pos-select"></select><select id="neg-select"></select>`;
+    importLists({
+      presets: [
+        { id: 'p1', title: 'p1', type: 'positive', items: ['a'] },
+        { id: 'n1', title: 'n1', type: 'negative', items: ['b'] }
+      ]
+    });
+    expect(lists.POS_PRESETS.p1).toEqual(['a']);
+    expect(lists.NEG_PRESETS.n1).toEqual(['b']);
+  });
+
+  test('exportState and importState round trip', () => {
+    const { state, exportState, importState } = require('../src/state');
+    state.shuffle.base = true;
+    state.seed = 123;
+    const json = exportState();
+    state.shuffle.base = false;
+    state.seed = null;
+    importState(JSON.parse(json));
+    expect(state.shuffle.base).toBe(true);
+    expect(state.seed).toBe(123);
+  });
 });


### PR DESCRIPTION
## Summary
- introduce `state.js` for shared app state and serialization helpers
- refactor list manager to use the new state object
- expose the state module via `script.js`
- test state round trips and list loading behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867da628df48321a6f91a7ee15ab1a9