### PR TITLE
Add state persistence

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,6 +53,14 @@
         </div>
         <div class="input-group">
           <div class="label-row">
+            <label>State</label>
+            <input type="file" id="state-file" accept="application/json" style="display:none">
+            <button type="button" id="load-state">Load State</button>
+            <button type="button" id="save-state">Save State</button>
+          </div>
+        </div>
+        <div class="input-group">
+          <div class="label-row">
             <label for="divider-input">Divider List</label>
             <div class="button-col">
               <input type="checkbox" id="divider-shuffle" hidden>

--- a/src/script.js
+++ b/src/script.js
@@ -2,6 +2,7 @@
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
   const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const ui = global.uiControls || (typeof require !== 'undefined' && require('./uiControls'));
+  const state = global.stateManager || (typeof require !== 'undefined' && require('./state'));
 
   if (typeof document !== 'undefined' && !(typeof window !== 'undefined' && window.__TEST__)) {
     const init = ui.initializeUI;
@@ -13,6 +14,6 @@
   }
 
   if (typeof module !== 'undefined') {
-    module.exports = { ...utils, ...lists, ...ui };
+    module.exports = { ...utils, ...lists, ...ui, ...state };
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,125 @@
+(function (global) {
+  function collectState() {
+    const get = id => document.getElementById(id);
+    return {
+      text: {
+        base: get('base-input')?.value || '',
+        positive: get('pos-input')?.value || '',
+        negative: get('neg-input')?.value || '',
+        dividers: get('divider-input')?.value || '',
+        lyrics: get('lyrics-input')?.value || ''
+      },
+      presets: {
+        base: get('base-select')?.value || '',
+        positive: get('pos-select')?.value || '',
+        negative: get('neg-select')?.value || '',
+        divider: get('divider-select')?.value || '',
+        length: get('length-select')?.value || '',
+        lyrics: get('lyrics-select')?.value || ''
+      },
+      stack: {
+        includePosForNeg: get('neg-include-pos')?.checked || false,
+        posStack: get('pos-stack')?.checked || false,
+        posStackSize: get('pos-stack-size')?.value || '1',
+        negStack: get('neg-stack')?.checked || false,
+        negStackSize: get('neg-stack-size')?.value || '1'
+      },
+      shuffleSettings: {
+        base: get('base-shuffle')?.checked || false,
+        positive: get('pos-shuffle')?.checked || false,
+        negative: get('neg-shuffle')?.checked || false,
+        divider: get('divider-shuffle')?.checked || false
+      },
+      length: {
+        limit: get('length-input')?.value || ''
+      },
+      shuffleOrders: {},
+      insertionPositions: []
+    };
+  }
+
+  function applyState(state) {
+    if (!state || typeof state !== 'object') return;
+    const get = id => document.getElementById(id);
+    if (state.text) {
+      if (get('base-input')) get('base-input').value = state.text.base || '';
+      if (get('pos-input')) get('pos-input').value = state.text.positive || '';
+      if (get('neg-input')) get('neg-input').value = state.text.negative || '';
+      if (get('divider-input')) get('divider-input').value = state.text.dividers || '';
+      if (get('lyrics-input')) get('lyrics-input').value = state.text.lyrics || '';
+    }
+    if (state.presets) {
+      if (get('base-select')) get('base-select').value = state.presets.base || '';
+      if (get('pos-select')) get('pos-select').value = state.presets.positive || '';
+      if (get('neg-select')) get('neg-select').value = state.presets.negative || '';
+      if (get('divider-select')) get('divider-select').value = state.presets.divider || '';
+      if (get('length-select')) get('length-select').value = state.presets.length || '';
+      if (get('lyrics-select')) get('lyrics-select').value = state.presets.lyrics || '';
+    }
+    if (state.stack) {
+      if (get('neg-include-pos')) get('neg-include-pos').checked = !!state.stack.includePosForNeg;
+      if (get('pos-stack')) get('pos-stack').checked = !!state.stack.posStack;
+      if (get('pos-stack-size')) get('pos-stack-size').value = state.stack.posStackSize || '1';
+      if (get('neg-stack')) get('neg-stack').checked = !!state.stack.negStack;
+      if (get('neg-stack-size')) get('neg-stack-size').value = state.stack.negStackSize || '1';
+    }
+    if (state.shuffleSettings) {
+      if (get('base-shuffle')) get('base-shuffle').checked = !!state.shuffleSettings.base;
+      if (get('pos-shuffle')) get('pos-shuffle').checked = !!state.shuffleSettings.positive;
+      if (get('neg-shuffle')) get('neg-shuffle').checked = !!state.shuffleSettings.negative;
+      if (get('divider-shuffle')) get('divider-shuffle').checked = !!state.shuffleSettings.divider;
+    }
+    if (state.length && get('length-input')) {
+      get('length-input').value = state.length.limit || '';
+    }
+  }
+
+  function exportState() {
+    return JSON.stringify(collectState(), null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj) return;
+    applyState(obj);
+  }
+
+  function loadStateFromFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result);
+        importState(data);
+      } catch (err) {
+        alert('Invalid state file');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  function downloadState() {
+    const blob = new Blob([exportState()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'state.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  const api = {
+    collectState,
+    applyState,
+    exportState,
+    importState,
+    loadStateFromFile,
+    downloadState
+  };
+
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.stateManager = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -1,6 +1,7 @@
 (function (global) {
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
   const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
+  const state = global.stateManager || (typeof require !== 'undefined' && require('./state'));
 
   function applyPreset(selectEl, inputEl, presetsOrType) {
     let presets = presetsOrType;
@@ -85,6 +86,7 @@
   }
 
   function generate() {
+    const currentState = state.collectState();
     const {
       baseItems,
       negMods,
@@ -121,6 +123,9 @@
       negStackOn ? negStackSize : 1
     );
     displayOutput(result);
+
+    currentState.shuffleOrders = {};
+    state.applyState(currentState);
 
     const lyricsInput = document.getElementById('lyrics-input');
     if (lyricsInput && lyricsInput.value.trim()) {
@@ -346,6 +351,21 @@
     if (divSave) divSave.addEventListener('click', () => lists.saveList('divider'));
     const lyricsSave = document.getElementById('lyrics-save');
     if (lyricsSave) lyricsSave.addEventListener('click', () => lists.saveList('lyrics'));
+
+    const saveStateBtn = document.getElementById('save-state');
+    if (saveStateBtn) saveStateBtn.addEventListener('click', state.downloadState);
+    const loadStateBtn = document.getElementById('load-state');
+    const stateFile = document.getElementById('state-file');
+    if (loadStateBtn && stateFile) {
+      loadStateBtn.addEventListener('click', () => stateFile.click());
+    }
+    if (stateFile) {
+      stateFile.addEventListener('change', e => {
+        const f = e.target.files[0];
+        if (f) state.loadStateFromFile(f);
+        stateFile.value = '';
+      });
+    }
   }
 
   const api = {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -554,3 +554,79 @@ describe('List persistence', () => {
     expect(lists.length).toBe(2);
   });
 });
+
+describe('State persistence', () => {
+  const stateMod = require('../src/state');
+
+  test('saved state restores output with same seed', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input"></textarea>
+      <textarea id="neg-input"></textarea>
+      <textarea id="pos-input"></textarea>
+      <textarea id="divider-input"></textarea>
+      <textarea id="lyrics-input"></textarea>
+      <input id="length-input">
+      <select id="length-select"></select>
+      <input type="checkbox" id="base-shuffle">
+      <input type="checkbox" id="pos-shuffle">
+      <input type="checkbox" id="neg-shuffle">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-stack">
+      <select id="neg-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-include-pos">
+      <input type="checkbox" id="divider-shuffle">
+      <pre id="positive-output"></pre>
+      <pre id="negative-output"></pre>
+      <pre id="lyrics-output"></pre>
+    `;
+
+    importLists({ presets: [] });
+    document.getElementById('base-input').value = 'a,b';
+    document.getElementById('pos-input').value = 'p1,p2';
+    document.getElementById('neg-input').value = 'n1';
+    document.getElementById('length-input').value = '50';
+
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0.5);
+    ui.generate();
+    const pos1 = document.getElementById('positive-output').textContent;
+    const neg1 = document.getElementById('negative-output').textContent;
+    Math.random = orig;
+
+    const saved = stateMod.exportState();
+
+    document.body.innerHTML = `
+      <textarea id="base-input"></textarea>
+      <textarea id="neg-input"></textarea>
+      <textarea id="pos-input"></textarea>
+      <textarea id="divider-input"></textarea>
+      <textarea id="lyrics-input"></textarea>
+      <input id="length-input">
+      <select id="length-select"></select>
+      <input type="checkbox" id="base-shuffle">
+      <input type="checkbox" id="pos-shuffle">
+      <input type="checkbox" id="neg-shuffle">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-stack">
+      <select id="neg-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-include-pos">
+      <input type="checkbox" id="divider-shuffle">
+      <pre id="positive-output"></pre>
+      <pre id="negative-output"></pre>
+      <pre id="lyrics-output"></pre>
+    `;
+
+    importLists({ presets: [] });
+    stateMod.importState(JSON.parse(saved));
+    Math.random = jest.fn().mockReturnValue(0.5);
+    ui.generate();
+    const pos2 = document.getElementById('positive-output').textContent;
+    const neg2 = document.getElementById('negative-output').textContent;
+    Math.random = orig;
+
+    expect(pos2).toBe(pos1);
+    expect(neg2).toBe(neg1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `state` module for saving/loading UI state
- hook state management into script and UI
- expose buttons for downloading/uploading state
- ensure saved state round trips via new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867da9517988321b7eb603714f4f428