### PR TITLE
Add state manager and tests

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -242,6 +242,7 @@
   <!-- Load submodules before main script -->
   <script src="promptUtils.js"></script>
   <script src="listManager.js"></script>
+  <script src="stateManager.js"></script>
   <script src="uiControls.js"></script>
   <!-- Then load main application logic -->
   <script src="script.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -2,6 +2,7 @@
   const utils = global.promptUtils || (typeof require !== 'undefined' && require('./promptUtils'));
   const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const ui = global.uiControls || (typeof require !== 'undefined' && require('./uiControls'));
+  const state = global.stateManager || (typeof require !== 'undefined' && require('./stateManager'));
 
   if (typeof document !== 'undefined' && !(typeof window !== 'undefined' && window.__TEST__)) {
     const init = ui.initializeUI;
@@ -13,6 +14,6 @@
   }
 
   if (typeof module !== 'undefined') {
-    module.exports = { ...utils, ...lists, ...ui };
+    module.exports = { ...utils, ...lists, ...ui, ...state };
   }
 })(typeof window !== 'undefined' ? window : global);

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -1,0 +1,95 @@
+(function (global) {
+  const State = {};
+
+  function getVal(el) {
+    if (!el) return undefined;
+    if (el.type === 'checkbox') return el.checked;
+    return el.value;
+  }
+
+  function setVal(el, val) {
+    if (!el) return;
+    if (el.type === 'checkbox') {
+      el.checked = !!val;
+    } else {
+      el.value = val != null ? val : '';
+    }
+    el.dispatchEvent(new Event('change'));
+  }
+
+  const FIELD_IDS = [
+    'base-input',
+    'base-select',
+    'base-shuffle',
+    'pos-input',
+    'pos-select',
+    'pos-shuffle',
+    'pos-stack',
+    'pos-stack-size',
+    'neg-input',
+    'neg-select',
+    'neg-shuffle',
+    'neg-stack',
+    'neg-stack-size',
+    'neg-include-pos',
+    'divider-input',
+    'divider-select',
+    'divider-shuffle',
+    'length-input',
+    'length-select',
+    'lyrics-input',
+    'lyrics-select',
+    'lyrics-space',
+    'lyrics-remove-parens',
+    'lyrics-remove-brackets'
+  ];
+
+  function loadFromDOM() {
+    const obj = {};
+    FIELD_IDS.forEach(id => {
+      const el = typeof document !== 'undefined' && document.getElementById(id);
+      if (el) obj[id] = getVal(el);
+    });
+    Object.keys(State).forEach(k => delete State[k]);
+    Object.assign(State, obj);
+    return obj;
+  }
+
+  function applyToDOM(state) {
+    if (!state) return;
+    FIELD_IDS.forEach(id => {
+      if (Object.prototype.hasOwnProperty.call(state, id)) {
+        const el = typeof document !== 'undefined' && document.getElementById(id);
+        setVal(el, state[id]);
+      }
+    });
+    Object.keys(State).forEach(k => delete State[k]);
+    Object.assign(State, state);
+  }
+
+  function exportState() {
+    return JSON.stringify(State, null, 2);
+  }
+
+  function importState(obj) {
+    if (!obj) return;
+    let data = obj;
+    if (typeof obj === 'string') {
+      try {
+        data = JSON.parse(obj);
+      } catch (err) {
+        return;
+      }
+    }
+    if (typeof data !== 'object') return;
+    applyToDOM(data);
+  }
+
+  const api = { State, loadFromDOM, applyToDOM, exportState, importState };
+
+  if (typeof module !== 'undefined') {
+    module.exports = api;
+  } else {
+    global.stateManager = api;
+  }
+})(typeof window !== 'undefined' ? window : global);

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+
+global.__TEST__ = true;
+if (typeof window !== 'undefined') window.__TEST__ = true;
+
+const lists = require('../src/listManager');
+const ui = require('../src/uiControls');
+const state = require('../src/stateManager');
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <select id="base-select"></select>
+    <textarea id="base-input"></textarea>
+    <input type="checkbox" id="base-shuffle">
+    <select id="pos-select"></select>
+    <textarea id="pos-input"></textarea>
+    <input type="checkbox" id="pos-shuffle">
+    <input type="checkbox" id="pos-stack">
+    <select id="pos-stack-size"><option value="2">2</option></select>
+    <select id="neg-select"></select>
+    <textarea id="neg-input"></textarea>
+    <input type="checkbox" id="neg-shuffle">
+    <input type="checkbox" id="neg-stack">
+    <select id="neg-stack-size"><option value="2">2</option></select>
+    <input type="checkbox" id="neg-include-pos">
+    <select id="divider-select"></select>
+    <textarea id="divider-input"></textarea>
+    <input type="checkbox" id="divider-shuffle">
+    <select id="length-select"></select>
+    <input id="length-input">
+    <select id="lyrics-select"></select>
+    <textarea id="lyrics-input"></textarea>
+    <select id="lyrics-space"><option value="1">1</option><option value="2">2</option></select>
+    <input type="checkbox" id="lyrics-remove-parens">
+    <input type="checkbox" id="lyrics-remove-brackets">
+    <pre id="positive-output"></pre>
+    <pre id="negative-output"></pre>
+    <pre id="lyrics-output"></pre>
+    <button id="generate"></button>
+  `;
+}
+
+function sampleLists() {
+  return {
+    presets: [
+      { id: 'neg', title: 'neg', type: 'negative', items: ['bad'] },
+      { id: 'pos', title: 'pos', type: 'positive', items: ['good'] },
+      { id: 'len', title: 'len', type: 'length', items: ['20'] },
+      { id: 'div', title: 'div', type: 'divider', items: ['\nfoo '] },
+      { id: 'base', title: 'base', type: 'base', items: ['cat'] },
+      { id: 'ly', title: 'ly', type: 'lyrics', items: ['la'] }
+    ]
+  };
+}
+
+describe('State manager integration', () => {
+  beforeEach(() => {
+    setupDOM();
+    lists.importLists(sampleLists());
+    ui.initializeUI();
+    global.alert = jest.fn();
+  });
+
+  test('export and import round trip preserves generation', () => {
+    ui.generate();
+    const firstPos = document.getElementById('positive-output').textContent;
+    const firstNeg = document.getElementById('negative-output').textContent;
+
+    state.loadFromDOM();
+    const json = state.exportState();
+
+    document.getElementById('base-input').value = 'dog';
+    ui.generate();
+    expect(document.getElementById('positive-output').textContent).not.toBe(firstPos);
+
+    state.importState(JSON.parse(json));
+    ui.generate();
+    expect(document.getElementById('positive-output').textContent).toBe(firstPos);
+    expect(document.getElementById('negative-output').textContent).toBe(firstNeg);
+
+    const again = state.exportState();
+    expect(again).toBe(json);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `stateManager.js` module
- expose `stateManager` from `script.js`
- load the new module in `index.html`
- test state round trips and generation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867e0bef94483219ede5923519f5a9c