### PR TITLE
Add deterministic order controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,6 @@ entry in `ALL_LISTS.presets` has the shape:
 `type` can be `negative`, `positive` or `length` (length lists contain a single
 numeric value). The file is large but purely data driven, so you rarely need to
 inspect it when working on functionality.
+
+An additional preset type `order` contains numeric sequences used for insertion
+depths or item reorderings.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The Prompt Enhancer helps you create more effective prompts by:
 - **No Dependencies**: Pure vanilla JavaScript, works completely offline
 - **Dark Theme**: Eye-friendly interface inspired by Diskrot
 - **Quick Copy Buttons**: Every textbox has a copy icon that briefly turns blue with a check mark when clicked
+- **Insertion Depths**: Specify numeric lists for modifier insertion positions
+- **State Saving**: Export and reload all current inputs for repeatable output
+- **Deterministic Ordering**: Canonical or randomized lists control item ordering
 
 ## How to Use
 

--- a/src/all_lists.js
+++ b/src/all_lists.js
@@ -705,9 +705,15 @@ const ALL_LISTS = {
         "Namely, ",
         "Rephrased, ",
         "To say it another way, ",
-        "Let me put it this way. "
-      ],
-      "type": "divider"
+    "Let me put it this way. "
+  ],
+  "type": "divider"
+    },
+    {
+      "id": "sample-order",
+      "title": "Sample Order",
+      "items": ["0", "1", "2"],
+      "type": "order"
     }
   ]
 };

--- a/src/index.html
+++ b/src/index.html
@@ -39,14 +39,15 @@
             <button type="button" id="load-lists">Load</button>
             <button type="button" id="additive-load">Additive Load</button>
             <button type="button" id="download-lists">Save</button>
+            <input type="file" id="state-file" accept="application/json" style="display:none">
+            <button type="button" id="load-state">Load State</button>
+            <button type="button" id="save-state">Save State</button>
           </div>
         </div>
         <!-- Hide all toggle -->
         <div class="input-group">
           <div class="label-row">
             <label>Quick Actions</label>
-            <input type="checkbox" id="all-random" hidden>
-            <button type="button" class="toggle-button" data-target="all-random" data-on="All randomized" data-off="All Canonical">All Canonical</button>
             <input type="checkbox" id="all-hide" hidden>
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
           </div>
@@ -56,7 +57,6 @@
             <label for="divider-input">Divider List</label>
             <div class="button-col">
               <input type="checkbox" id="divider-shuffle" hidden>
-              <button type="button" class="toggle-button icon-button random-button" data-target="divider-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
               <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
               <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
               <input type="checkbox" id="divider-hide" data-targets="divider-input" hidden>
@@ -74,7 +74,6 @@
             <label for="base-input">Base Prompt List</label>
             <div class="button-col">
               <input type="checkbox" id="base-shuffle" hidden>
-              <button type="button" class="toggle-button icon-button random-button" data-target="base-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
               <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
               <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
               <input type="checkbox" id="base-hide" data-targets="base-input" hidden>
@@ -85,6 +84,10 @@
           <div class="input-row">
             <textarea id="base-input" rows="4" placeholder="Enter comma, semicolon, or newline separated items"></textarea>
           </div>
+          <select id="base-order-select"></select>
+          <div class="input-row">
+            <textarea id="base-order-input" rows="1" placeholder="0,1,2"></textarea>
+          </div>
         </div>
         <!-- Positive modifier selection section -->
         <div class="input-group">
@@ -94,7 +97,6 @@
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
                 <input type="checkbox" id="pos-shuffle" hidden>
-                <button type="button" class="toggle-button icon-button random-button" data-target="pos-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
                 <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="pos-hide" data-targets="pos-input" hidden>
@@ -112,6 +114,10 @@
           <div class="input-row">
             <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
           </div>
+          <select id="pos-order-select"></select>
+          <div class="input-row">
+            <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+          </div>
         </div>
         <!-- Negative modifier selection section -->
         <div class="input-group">
@@ -123,7 +129,6 @@
             <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
               <div class="button-col">
                 <input type="checkbox" id="neg-shuffle" hidden>
-                <button type="button" class="toggle-button icon-button random-button" data-target="neg-shuffle" data-on="🎲" data-off="🎲">&#127922;</button>
                 <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="neg-hide" data-targets="neg-input" hidden>
@@ -141,6 +146,10 @@
           <div class="input-row">
             <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
           </div>
+          <select id="neg-order-select"></select>
+          <div class="input-row">
+            <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+          </div>
         </div>
         <!-- Character length limit selection -->
         <div class="input-group">
@@ -156,11 +165,26 @@
         <select id="length-select">
           <!-- Options will be populated dynamically from LENGTH_LISTS -->
         </select>
-        <div class="input-row">
-          <input type="number" id="length-input" value="1000" min="1">
+      <div class="input-row">
+        <input type="number" id="length-input" value="1000" min="1">
+      </div>
+    </div>
+    <div class="input-group">
+      <div class="label-row">
+        <label for="insert-input">Insertion Depths</label>
+        <div class="button-col">
+          <button type="button" id="insert-save" class="save-button icon-button" title="Save">&#128190;</button>
+          <button type="button" class="copy-button icon-button" data-target="insert-input" title="Copy">&#128203;</button>
+          <input type="checkbox" id="insert-hide" data-targets="insert-input,insert-select" hidden>
+          <button type="button" class="toggle-button icon-button hide-button" data-target="insert-hide" data-on="☰" data-off="✖">☰</button>
         </div>
       </div>
-      <!-- Lyrics processing input -->
+      <select id="insert-select"></select>
+      <div class="input-row">
+        <textarea id="insert-input" rows="2" placeholder="0,1,2"></textarea>
+      </div>
+    </div>
+    <!-- Lyrics processing input -->
       <div class="input-group">
         <div class="label-row">
           <label for="lyrics-input">Lyrics</label>

--- a/src/listManager.js
+++ b/src/listManager.js
@@ -6,6 +6,7 @@
   let DIVIDER_PRESETS = {};
   let BASE_PRESETS = {};
   let LYRICS_PRESETS = {};
+  let ORDER_PRESETS = {};
 
   let LISTS;
   if (typeof ALL_LISTS !== 'undefined' && Array.isArray(ALL_LISTS.presets)) {
@@ -55,6 +56,7 @@
     const divs = [];
     const base = [];
     const lyrics = [];
+    const order = [];
     if (LISTS.presets && Array.isArray(LISTS.presets)) {
       LISTS.presets.forEach(p => {
         if (p.type === 'negative') {
@@ -75,6 +77,9 @@
         } else if (p.type === 'lyrics') {
           LYRICS_PRESETS[p.id] = p.items || [];
           lyrics.push(p);
+        } else if (p.type === 'order') {
+          ORDER_PRESETS[p.id] = p.items || [];
+          order.push(p);
         }
       });
     }
@@ -90,6 +95,8 @@
     if (baseSelect) populateSelect(baseSelect, base);
     const lyricsSelect = document.getElementById('lyrics-select');
     if (lyricsSelect) populateSelect(lyricsSelect, lyrics);
+    const orderSelect = document.getElementById('insert-select');
+    if (orderSelect) populateSelect(orderSelect, order);
   }
 
   function exportLists() {
@@ -162,7 +169,8 @@
       positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
       length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
       divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS },
+      order: { select: 'insert-select', input: 'insert-input', store: ORDER_PRESETS }
     };
     const cfg = map[type];
     if (!cfg) return;
@@ -201,6 +209,7 @@
     get DIVIDER_PRESETS() { return DIVIDER_PRESETS; },
     get BASE_PRESETS() { return BASE_PRESETS; },
     get LYRICS_PRESETS() { return LYRICS_PRESETS; },
+    get ORDER_PRESETS() { return ORDER_PRESETS; },
     loadLists,
     exportLists,
     importLists,

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -50,6 +50,39 @@
     return raw.split(/\r?\n/).filter(line => line !== '');
   }
 
+  function parseOrderInput(raw) {
+    if (!raw) return [];
+    return raw
+      .split(/[,\s]+/)
+      .map(s => parseInt(s, 10))
+      .filter(n => !isNaN(n));
+  }
+
+  function applyOrder(items, order) {
+    if (!Array.isArray(order) || !order.length) return items.slice();
+    return items.map((_, i) => {
+      const idx = order[i % order.length];
+      return items[idx % items.length];
+    });
+  }
+
+  function insertAtDepth(phrase, term, depth) {
+    if (!term) return phrase;
+    const match = phrase.match(/([,.!:;?\n]\s*)$/);
+    let tail = '';
+    let body = phrase;
+    if (match) {
+      tail = match[1];
+      body = phrase.slice(0, -tail.length).trim();
+    } else {
+      body = phrase.trim();
+    }
+    const words = body ? body.split(/\s+/) : [];
+    const idx = depth % (words.length + 1);
+    words.splice(idx, 0, term);
+    return words.join(' ') + tail;
+  }
+
   function shuffle(arr) {
     for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -67,15 +100,18 @@
     orderedItems,
     prefixes,
     limit,
-    shufflePrefixes = false,
+    prefixOrder = null,
     delimited = false,
-    dividers = []
+    dividers = [],
+    itemOrder = null,
+    depths = null
   ) {
     if (!Array.isArray(orderedItems) || orderedItems.length === 0) return [];
-    const items = orderedItems.slice();
-    const prefixPool = prefixes.slice();
-    if (shufflePrefixes) shuffle(prefixPool);
+    let items = orderedItems.slice();
+    if (itemOrder) items = applyOrder(items, itemOrder);
+    const prefixPool = prefixOrder ? applyOrder(prefixes, prefixOrder) : prefixes.slice();
     const dividerPool = dividers.slice();
+    const depthPool = Array.isArray(depths) ? depths.slice() : null;
     const result = [];
     let idx = 0;
     let divIdx = 0;
@@ -83,7 +119,8 @@
       const needDivider = idx > 0 && idx % items.length === 0 && dividerPool.length;
       const prefix = prefixPool.length ? prefixPool[idx % prefixPool.length] : '';
       const item = items[idx % items.length];
-      const term = prefix ? `${prefix} ${item}` : item;
+      const depth = depthPool ? depthPool[idx % depthPool.length] : 0;
+      const term = prefix ? insertAtDepth(item, prefix, depth) : item;
       const pieces = [];
       if (needDivider) pieces.push(dividerPool[divIdx % dividerPool.length]);
       pieces.push(term);
@@ -106,24 +143,19 @@
     modifiers,
     limit,
     stackSize = 1,
-    shuffleMods = false,
+    modOrder = null,
     delimited = false,
-    dividers = []
+    dividers = [],
+    itemOrder = null,
+    depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    if (count === 1) {
-      const mods = modifiers.slice();
-      if (shuffleMods) shuffle(mods);
-      return buildPrefixedList(baseItems, mods, limit, false, delimited, dividers);
-    }
-    const orders = [];
-    for (let i = 0; i < count; i++) {
-      const mods = modifiers.slice();
-      shuffle(mods);
-      orders.push(mods);
-    }
+    const orderedMods = modOrder ? applyOrder(modifiers, modOrder) : modifiers.slice();
+    const orders = Array(count).fill(orderedMods);
     const dividerPool = dividers.slice();
-    const items = baseItems.slice();
+    let items = baseItems.slice();
+    if (itemOrder) items = applyOrder(items, itemOrder);
+    const depthPool = Array.isArray(depths) ? depths.slice() : null;
     const result = [];
     let idx = 0;
     let divIdx = 0;
@@ -132,7 +164,8 @@
       let term = items[idx % items.length];
       orders.forEach(mods => {
         const mod = mods[idx % mods.length];
-        term = mod ? `${mod} ${term}` : term;
+        const depth = depthPool ? depthPool[idx % depthPool.length] : 0;
+        term = mod ? insertAtDepth(term, mod, depth) : term;
       });
       const pieces = [];
       if (needDivider) pieces.push(dividerPool[divIdx % dividerPool.length]);
@@ -156,22 +189,23 @@
     negMods,
     limit,
     stackSize = 1,
-    shuffleMods = false,
+    modOrder = null,
     delimited = false,
-    dividers = []
+    dividers = [],
+    itemOrder = null,
+    depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    const orders = [];
-    for (let i = 0; i < count; i++) {
-      const mods = negMods.slice();
-      if (shuffleMods) shuffle(mods);
-      orders.push(mods);
-    }
+    const orderedMods = modOrder ? applyOrder(negMods, modOrder) : negMods.slice();
+    const orders = Array(count).fill(orderedMods);
     const dividerSet = new Set(dividers);
     const result = [];
     let modIdx = 0;
-    for (let i = 0; i < posTerms.length; i++) {
-      const base = posTerms[i];
+    let items = posTerms.slice();
+    if (itemOrder) items = applyOrder(items, itemOrder);
+    const depthPool = Array.isArray(depths) ? depths.slice() : null;
+    for (let i = 0; i < items.length; i++) {
+      const base = items[i];
       if (dividerSet.has(base)) {
         const candidate =
           (result.length ? result.join(delimited ? '' : ', ') + (delimited ? '' : ', ') : '') +
@@ -183,7 +217,8 @@
       let term = base;
       orders.forEach(mods => {
         const mod = mods[modIdx % mods.length];
-        term = mod ? `${mod} ${term}` : term;
+        const depth = depthPool ? depthPool[modIdx % depthPool.length] : 0;
+        term = mod ? insertAtDepth(term, mod, depth) : term;
       });
       const candidate =
         (result.length ? result.join(delimited ? '' : ', ') + (delimited ? '' : ', ') : '') +
@@ -199,20 +234,21 @@
     items,
     negMods,
     posMods,
-    shuffleBase,
-    shuffleNeg,
-    shufflePos,
     limit,
     includePosForNeg = false,
     dividers = [],
     shuffleDividers = true,
     posStackSize = 1,
-    negStackSize = 1
+    negStackSize = 1,
+    depths = null,
+    baseOrder = null,
+    posOrder = null,
+    negOrder = null
   ) {
     if (!items.length) {
       return { positive: '', negative: '' };
     }
-    if (shuffleBase) shuffle(items);
+    if (Array.isArray(baseOrder)) items = applyOrder(items, baseOrder);
     const delimited = /[,.!:;?\n]\s*$/.test(items[0]);
     const dividerPool = dividers.map(d => (d.startsWith('\n') ? d : '\n' + d));
     if (dividerPool.length && shuffleDividers) shuffle(dividerPool);
@@ -221,9 +257,11 @@
       posMods,
       limit,
       posStackSize,
-      shufflePos,
+      posOrder,
       delimited,
-      dividerPool
+      dividerPool,
+      baseOrder,
+      depths
     );
     const negTerms = includePosForNeg
       ? applyNegativeOnPositive(
@@ -231,18 +269,22 @@
           negMods,
           limit,
           negStackSize,
-          shuffleNeg,
+          negOrder,
           delimited,
-          dividerPool
+          dividerPool,
+          baseOrder,
+          depths
         )
       : applyModifierStack(
           items,
           negMods,
           limit,
           negStackSize,
-          shuffleNeg,
+          negOrder,
           delimited,
-          dividerPool
+          dividerPool,
+          baseOrder,
+          depths
         );
     const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
     return {
@@ -278,6 +320,9 @@
   const api = {
     parseInput,
     parseDividerInput,
+    parseOrderInput,
+    applyOrder,
+    insertAtDepth,
     shuffle,
     equalizeLength,
     buildPrefixedList,

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -41,7 +41,15 @@
     'lyrics-select',
     'lyrics-space',
     'lyrics-remove-parens',
-    'lyrics-remove-brackets'
+    'lyrics-remove-brackets',
+    'insert-input',
+    'insert-select',
+    'base-order-input',
+    'base-order-select',
+    'pos-order-input',
+    'pos-order-select',
+    'neg-order-input',
+    'neg-order-select'
   ];
 
   function loadFromDOM() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -17,6 +17,9 @@ const {
   buildVersions,
   processLyrics,
   parseDividerInput,
+  parseOrderInput,
+  applyOrder,
+  insertAtDepth,
 } = utils;
 
 const { exportLists, importLists, saveList } = lists;
@@ -72,6 +75,19 @@ describe('Utility functions', () => {
     expect(a).toEqual([1]);
     expect(b).toEqual(['x']);
   });
+
+  test('parseOrderInput converts to numbers', () => {
+    expect(parseOrderInput('1, 2 3')).toEqual([1, 2, 3]);
+  });
+
+  test('applyOrder reorders list cycling values', () => {
+    const out = applyOrder(['a', 'b', 'c'], [2, 0]);
+    expect(out).toEqual(['c', 'a', 'c']);
+  });
+
+  test('insertAtDepth inserts term at depth', () => {
+    expect(insertAtDepth('a b c', 'x', 1)).toBe('a x b c');
+  });
 });
 
 describe('Prompt building', () => {
@@ -104,27 +120,27 @@ describe('Prompt building', () => {
   });
 
   test('buildVersions builds positive and negative prompts', () => {
-    const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20);
+    const out = buildVersions(['cat'], ['bad'], ['good'], 20);
     expect(out).toEqual({ positive: 'good cat, good cat', negative: 'bad cat, bad cat' });
   });
 
   test('buildVersions can include positive terms for negatives', () => {
-    const out = buildVersions(['cat'], ['bad'], ['good'], false, false, false, 20, true);
+    const out = buildVersions(['cat'], ['bad'], ['good'], 20, true);
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
   });
 
   test('buildVersions returns empty strings when items list is empty', () => {
-    const out = buildVersions([], ['n'], ['p'], false, false, false, 10);
+    const out = buildVersions([], ['n'], ['p'], 10);
     expect(out).toEqual({ positive: '', negative: '' });
   });
 
   test('buildVersions respects very small limits', () => {
-    const out = buildVersions(['hello'], ['n'], ['p'], false, false, false, 2);
+    const out = buildVersions(['hello'], ['n'], ['p'], 2);
     expect(out).toEqual({ positive: '', negative: '' });
   });
 
   test('buildVersions joins items without commas when delimited', () => {
-    const out = buildVersions(['a.\n', 'b.\n'], ['n'], ['p'], false, false, false, 30);
+    const out = buildVersions(['a.\n', 'b.\n'], ['n'], ['p'], 30);
     expect(out.positive.includes(',')).toBe(false);
     expect(out.negative.includes(',')).toBe(false);
     expect(out.positive.startsWith('p a.\n')).toBe(true);
@@ -136,9 +152,6 @@ describe('Prompt building', () => {
       ['a', 'b'],
       [],
       [],
-      false,
-      false,
-      false,
       50,
       false,
       ['i.e., '],
@@ -154,9 +167,6 @@ describe('Prompt building', () => {
       ['a', 'b'],
       [],
       [],
-      false,
-      false,
-      false,
       50,
       false,
       divs
@@ -171,9 +181,6 @@ describe('Prompt building', () => {
       ['a', 'b'],
       [],
       [],
-      false,
-      false,
-      false,
       50,
       false,
       ['x ', 'y ']
@@ -190,9 +197,6 @@ describe('Prompt building', () => {
       ['a', 'b'],
       [],
       [],
-      false,
-      false,
-      false,
       50,
       false,
       ['\nfoo ']
@@ -208,9 +212,6 @@ describe('Prompt building', () => {
       ['x'],
       ['n1', 'n2'],
       ['p1', 'p2'],
-      false,
-      false,
-      false,
       10,
       false,
       [],
@@ -227,9 +228,6 @@ describe('Prompt building', () => {
       ['a', 'b'],
       ['n1'],
       ['p1'],
-      false,
-      false,
-      false,
       100,
       false,
       ['\nfoo '],
@@ -247,9 +245,6 @@ describe('Prompt building', () => {
       ['cat'],
       ['bad'],
       ['good'],
-      false,
-      false,
-      false,
       50,
       true,
       ['\nfoo ']

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -12,6 +12,8 @@ function setupDOM() {
     <select id="base-select"></select>
     <textarea id="base-input"></textarea>
     <input type="checkbox" id="base-shuffle">
+    <select id="base-order-select"></select>
+    <textarea id="base-order-input"></textarea>
     <select id="pos-select"></select>
     <textarea id="pos-input"></textarea>
     <input type="checkbox" id="pos-shuffle">
@@ -23,9 +25,15 @@ function setupDOM() {
     <input type="checkbox" id="neg-stack">
     <select id="neg-stack-size"><option value="2">2</option></select>
     <input type="checkbox" id="neg-include-pos">
+    <select id="pos-order-select"></select>
+    <textarea id="pos-order-input"></textarea>
+    <select id="neg-order-select"></select>
+    <textarea id="neg-order-input"></textarea>
     <select id="divider-select"></select>
     <textarea id="divider-input"></textarea>
     <input type="checkbox" id="divider-shuffle">
+    <select id="insert-select"></select>
+    <textarea id="insert-input"></textarea>
     <select id="length-select"></select>
     <input id="length-input">
     <select id="lyrics-select"></select>
@@ -48,7 +56,8 @@ function sampleLists() {
       { id: 'len', title: 'len', type: 'length', items: ['20'] },
       { id: 'div', title: 'div', type: 'divider', items: ['\nfoo '] },
       { id: 'base', title: 'base', type: 'base', items: ['cat'] },
-      { id: 'ly', title: 'ly', type: 'lyrics', items: ['la'] }
+      { id: 'ly', title: 'ly', type: 'lyrics', items: ['la'] },
+      { id: 'ord', title: 'ord', type: 'order', items: ['0'] }
     ]
   };
 }


### PR DESCRIPTION
## Summary
- support deterministic order lists for base, positive, and negative items
- add dropdowns for order selection and unify insertion depth control
- track new fields in state manager and tests
- update utilities to use order lists instead of runtime shuffling
- document deterministic ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e5ed13b88321a501d7a12c19fd49