### PR TITLE
Generate random orders at runtime

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -320,9 +320,7 @@
       if (select.value === 'canonical') {
         input.value = items.map((_, i) => i).join(', ');
       } else if (select.value === 'random') {
-        const arr = items.map((_, i) => i);
-        utils.shuffle(arr);
-        input.value = arr.join(', ');
+        input.value = '';
       } else if (lists.ORDER_PRESETS[select.value]) {
         input.value = lists.ORDER_PRESETS[select.value].join(', ');
       }
@@ -372,8 +370,7 @@
         input.value = counts.join(', ');
         return;
       }
-      const vals = counts.map(c => Math.floor(Math.random() * (c + 1)));
-      input.value = vals.join(', ');
+      input.value = '';
     }
     if (!select) return;
     select.addEventListener('change', () => {
@@ -407,13 +404,50 @@
 
   function rerollRandomOrders() {
     const toggle = document.getElementById('reroll-on-gen');
-    if (!toggle || !toggle.checked) return;
-    ['base-order-select', 'pos-order-select', 'neg-order-select', 'divider-order-select', 'insert-select'].forEach(id => {
-      const sel = document.getElementById(id);
-      if (sel && sel.value === 'random') {
-        sel.dispatchEvent(new Event('change'));
+    const allow = !toggle || toggle.checked;
+
+    const baseItems = utils.parseInput(
+      document.getElementById('base-input')?.value || '',
+      true
+    );
+    const posItems = utils.parseInput(document.getElementById('pos-input')?.value || '');
+    const negItems = utils.parseInput(document.getElementById('neg-input')?.value || '');
+    const divItems = utils.parseDividerInput(
+      document.getElementById('divider-input')?.value || ''
+    );
+
+    const configs = [
+      { sel: 'base-order-select', inp: 'base-order-input', items: baseItems },
+      { sel: 'pos-order-select', inp: 'pos-order-input', items: posItems },
+      { sel: 'neg-order-select', inp: 'neg-order-input', items: negItems },
+      { sel: 'divider-order-select', inp: 'divider-order-input', items: divItems }
+    ];
+
+    configs.forEach(cfg => {
+      const select = document.getElementById(cfg.sel);
+      const input = document.getElementById(cfg.inp);
+      if (!select || !input || select.value !== 'random') return;
+      if (allow || !input.value.trim()) {
+        const arr = cfg.items.map((_, i) => i);
+        utils.shuffle(arr);
+        input.value = arr.join(', ');
       }
     });
+
+    const insertSel = document.getElementById('insert-select');
+    const insertInp = document.getElementById('insert-input');
+    if (insertSel && insertInp && insertSel.value === 'random') {
+      const countWords = str => {
+        const cleaned = str.trim().replace(/[,.!:;?]$/, '');
+        if (!cleaned) return 0;
+        return cleaned.split(/\s+/).length;
+      };
+      if (allow || !insertInp.value.trim()) {
+        const counts = baseItems.map(b => countWords(b));
+        const vals = counts.map(c => Math.floor(Math.random() * (c + 1)));
+        insertInp.value = vals.join(', ');
+      }
+    }
   }
 
   function setupStateButtons() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -368,16 +368,14 @@ describe('UI interactions', () => {
       <button id="base-reroll" class="toggle-button random-button" data-select="base-order-select"></button>
     `;
     const orig = utils.shuffle;
-    utils.shuffle = jest.fn(arr => {
-      arr.reverse();
-      return arr;
-    });
+    utils.shuffle = jest.fn();
     setupOrderControl('base-order-select', 'base-order-input', () => ['a', 'b', 'c']);
     setupRerollButton('base-reroll', 'base-order-select');
     document.getElementById('base-reroll').click();
-    utils.shuffle = orig;
     expect(document.getElementById('base-order-select').value).toBe('random');
-    expect(document.getElementById('base-order-input').value).toBe('2, 1, 0');
+    expect(document.getElementById('base-order-input').value).toBe('');
+    expect(utils.shuffle).not.toHaveBeenCalled();
+    utils.shuffle = orig;
   });
 
   test('rerollRandomOrders updates random selects when enabled', () => {
@@ -388,22 +386,19 @@ describe('UI interactions', () => {
       </select>
       <textarea id="base-order-input"></textarea>
       <input type="checkbox" id="reroll-on-gen" checked>
+      <textarea id="base-input">a,b</textarea>
     `;
     const orig = utils.shuffle;
-    utils.shuffle = jest
-      .fn()
-      .mockImplementationOnce(arr => {
-        arr.reverse();
-        return arr;
-      })
-      .mockImplementationOnce(arr => arr);
+    utils.shuffle = jest.fn(arr => {
+      arr.reverse();
+      return arr;
+    });
     setupOrderControl('base-order-select', 'base-order-input', () => ['a', 'b']);
     document.getElementById('base-order-select').value = 'random';
     document.getElementById('base-order-select').dispatchEvent(new Event('change'));
-    const before = document.getElementById('base-order-input').value;
     rerollRandomOrders();
     utils.shuffle = orig;
-    expect(document.getElementById('base-order-input').value).not.toBe(before);
+    expect(document.getElementById('base-order-input').value).toBe('1, 0');
   });
 });
 


### PR DESCRIPTION
## Summary
- defer random order generation until prompts are produced
- keep depth and order inputs blank until generation
- adjust related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868bbfc09608321a7b56cc84b0694a2