### PR TITLE
Remove reroll on generate toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 - **Divider Ordering**: Control divider list order with canonical or random presets
 - **Quick Actions**: One toggle sets all list ordering menus to canonical or randomized
 - **Reroll Buttons**: Dice icons reroll random orders or switch the mode to random
-- **Reroll on Generate**: Quick action toggle controls whether random lists reroll each time
+- **Automatic Rerolls**: Random lists always reroll each time you generate
 
 ## How to Use
 

--- a/src/index.html
+++ b/src/index.html
@@ -52,8 +52,6 @@
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
             <input type="checkbox" id="all-random" hidden>
             <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="reroll-on-gen" checked hidden>
-            <button type="button" class="toggle-button" data-target="reroll-on-gen" data-on="Reroll On Gen" data-off="Static">Reroll On Gen</button>
           </div>
         </div>
         <div class="input-group">

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -51,8 +51,7 @@
     'neg-order-input',
     'neg-order-select',
     'divider-order-input',
-    'divider-order-select',
-    'reroll-on-gen'
+    'divider-order-select'
   ];
 
   function loadFromDOM() {

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -403,8 +403,6 @@
   }
 
   function rerollRandomOrders() {
-    const toggle = document.getElementById('reroll-on-gen');
-    const allow = !toggle || toggle.checked;
 
     const baseItems = utils.parseInput(
       document.getElementById('base-input')?.value || '',
@@ -427,11 +425,9 @@
       const select = document.getElementById(cfg.sel);
       const input = document.getElementById(cfg.inp);
       if (!select || !input || select.value !== 'random') return;
-      if (allow || !input.value.trim()) {
-        const arr = cfg.items.map((_, i) => i);
-        utils.shuffle(arr);
-        input.value = arr.join(', ');
-      }
+      const arr = cfg.items.map((_, i) => i);
+      utils.shuffle(arr);
+      input.value = arr.join(', ');
     });
 
     const insertSel = document.getElementById('insert-select');
@@ -442,11 +438,9 @@
         if (!cleaned) return 0;
         return cleaned.split(/\s+/).length;
       };
-      if (allow || !insertInp.value.trim()) {
-        const counts = baseItems.map(b => countWords(b));
-        const vals = counts.map(c => Math.floor(Math.random() * (c + 1)));
-        insertInp.value = vals.join(', ');
-      }
+      const counts = baseItems.map(b => countWords(b));
+      const vals = counts.map(c => Math.floor(Math.random() * (c + 1)));
+      insertInp.value = vals.join(', ');
     }
   }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -378,14 +378,13 @@ describe('UI interactions', () => {
     utils.shuffle = orig;
   });
 
-  test('rerollRandomOrders updates random selects when enabled', () => {
+  test('rerollRandomOrders updates random selects', () => {
     document.body.innerHTML = `
       <select id="base-order-select">
         <option value="canonical">c</option>
         <option value="random">r</option>
       </select>
       <textarea id="base-order-input"></textarea>
-      <input type="checkbox" id="reroll-on-gen" checked>
       <textarea id="base-input">a,b</textarea>
     `;
     const orig = utils.shuffle;

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -38,7 +38,6 @@ function setupDOM() {
     <textarea id="insert-input"></textarea>
     <select id="length-select"></select>
     <input id="length-input">
-    <input type="checkbox" id="reroll-on-gen">
     <select id="lyrics-select"></select>
     <textarea id="lyrics-input"></textarea>
     <select id="lyrics-space"><option value="1">1</option><option value="2">2</option></select>


### PR DESCRIPTION
## Summary
- drop `Reroll on Gen` quick action from the interface
- remove state entry for the toggle
- always reroll random lists on generation
- update docs to describe automatic reroll behaviour
- adjust tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868bed19bf483219a9df65b9a1682ce