### PR TITLE
Improve stacking order support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -123,9 +123,11 @@
           <div class="input-row">
             <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
           </div>
-          <select id="pos-order-select"></select>
-          <div class="input-row">
-            <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="pos-order-container">
+            <select id="pos-order-select"></select>
+            <div class="input-row">
+              <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+            </div>
           </div>
         </div>
         <!-- Negative modifier selection section -->
@@ -156,9 +158,11 @@
           <div class="input-row">
             <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
           </div>
-          <select id="neg-order-select"></select>
-          <div class="input-row">
-            <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="neg-order-container">
+            <select id="neg-order-select"></select>
+            <div class="input-row">
+              <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+            </div>
           </div>
         </div>
         <!-- Character length limit selection -->

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -143,15 +143,23 @@
     modifiers,
     limit,
     stackSize = 1,
-    modOrder = null,
+    modOrders = null,
     delimited = false,
     dividers = [],
     itemOrder = null,
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    const orderedMods = modOrder ? applyOrder(modifiers, modOrder) : modifiers.slice();
-    const orders = Array(count).fill(orderedMods);
+    const orders = [];
+    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+      for (let i = 0; i < count; i++) {
+        const ord = modOrders[i % modOrders.length];
+        orders.push(ord ? applyOrder(modifiers, ord) : modifiers.slice());
+      }
+    } else {
+      const orderedMods = modOrders ? applyOrder(modifiers, modOrders) : modifiers.slice();
+      for (let i = 0; i < count; i++) orders.push(orderedMods);
+    }
     const dividerPool = dividers.slice();
     let items = baseItems.slice();
     if (itemOrder) items = applyOrder(items, itemOrder);
@@ -189,15 +197,23 @@
     negMods,
     limit,
     stackSize = 1,
-    modOrder = null,
+    modOrders = null,
     delimited = false,
     dividers = [],
     itemOrder = null,
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    const orderedMods = modOrder ? applyOrder(negMods, modOrder) : negMods.slice();
-    const orders = Array(count).fill(orderedMods);
+    const orders = [];
+    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+      for (let i = 0; i < count; i++) {
+        const ord = modOrders[i % modOrders.length];
+        orders.push(ord ? applyOrder(negMods, ord) : negMods.slice());
+      }
+    } else {
+      const orderedMods = modOrders ? applyOrder(negMods, modOrders) : negMods.slice();
+      for (let i = 0; i < count; i++) orders.push(orderedMods);
+    }
     const dividerSet = new Set(dividers);
     const result = [];
     let modIdx = 0;

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -197,16 +197,13 @@
   function setupShuffleAll() {
     const allRandom = document.getElementById('all-random');
     if (!allRandom) return;
-    const selects = [
-      document.getElementById('base-order-select'),
-      document.getElementById('pos-order-select'),
-      document.getElementById('neg-order-select'),
-      document.getElementById('divider-order-select')
-    ].filter(Boolean);
+    const prefixes = ['base', 'pos', 'neg', 'divider'];
     const updateAll = () => {
-      selects.forEach(sel => {
-        sel.value = allRandom.checked ? 'random' : 'canonical';
-        sel.dispatchEvent(new Event('change'));
+      prefixes.forEach(prefix => {
+        forEachOrderControl(prefix, sel => {
+          sel.value = allRandom.checked ? 'random' : 'canonical';
+          sel.dispatchEvent(new Event('change'));
+        });
       });
       const btn = document.querySelector('.toggle-button[data-target="all-random"]');
       if (btn) updateButtonState(btn, allRandom);
@@ -356,6 +353,19 @@
     }
   }
 
+  function forEachOrderControl(prefix, cb) {
+    for (let i = 1; ; i++) {
+      const sel = document.getElementById(
+        `${prefix}-order-select${i === 1 ? '' : '-' + i}`
+      );
+      const inp = document.getElementById(
+        `${prefix}-order-input${i === 1 ? '' : '-' + i}`
+      );
+      if (!sel && !inp) break;
+      cb(sel, inp, i);
+    }
+  }
+
   function setupOrderControl(selectId, inputId, getItems) {
     const select = document.getElementById(selectId);
     const input = document.getElementById(inputId);
@@ -459,21 +469,17 @@
       document.getElementById('divider-input')?.value || ''
     );
 
-    const configs = [
-      { sel: 'base-order-select', inp: 'base-order-input', items: baseItems },
-      { sel: 'pos-order-select', inp: 'pos-order-input', items: posItems },
-      { sel: 'neg-order-select', inp: 'neg-order-input', items: negItems },
-      { sel: 'divider-order-select', inp: 'divider-order-input', items: divItems }
-    ];
-
-    configs.forEach(cfg => {
-      const select = document.getElementById(cfg.sel);
-      const input = document.getElementById(cfg.inp);
-      if (!select || !input || select.value !== 'random') return;
-      const arr = cfg.items.map((_, i) => i);
+    const applyRandom = (sel, inp, items) => {
+      if (sel.value !== 'random') return;
+      const arr = items.map((_, i) => i);
       utils.shuffle(arr);
-      input.value = arr.join(', ');
-    });
+      inp.value = arr.join(', ');
+    };
+
+    forEachOrderControl('base', (sel, inp) => applyRandom(sel, inp, baseItems));
+    forEachOrderControl('pos', (sel, inp) => applyRandom(sel, inp, posItems));
+    forEachOrderControl('neg', (sel, inp) => applyRandom(sel, inp, negItems));
+    forEachOrderControl('divider', (sel, inp) => applyRandom(sel, inp, divItems));
 
     const insertSel = document.getElementById('insert-select');
     const insertInp = document.getElementById('insert-input');

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -67,8 +67,18 @@
     }
     const insertDepths = utils.parseOrderInput(document.getElementById('insert-input')?.value || '');
     const baseOrder = utils.parseOrderInput(document.getElementById('base-order-input')?.value || '');
-    const posOrder = utils.parseOrderInput(document.getElementById('pos-order-input')?.value || '');
-    const negOrder = utils.parseOrderInput(document.getElementById('neg-order-input')?.value || '');
+    function collectOrders(prefix, count) {
+      const result = [];
+      for (let i = 1; i <= count; i++) {
+        const id = `${prefix}-order-input${i === 1 ? '' : '-' + i}`;
+        const el = document.getElementById(id);
+        result.push(utils.parseOrderInput(el?.value || ''));
+      }
+      return result;
+    }
+
+    const posOrder = collectOrders('pos', posStackOn ? posStackSize : 1);
+    const negOrder = collectOrders('neg', negStackOn ? negStackSize : 1);
     const dividerOrder = utils.parseOrderInput(document.getElementById('divider-order-input')?.value || '');
     return {
       baseItems,
@@ -207,8 +217,8 @@
 
   function setupStackControls() {
     const configs = [
-      { stack: 'pos-stack', size: 'pos-stack-size', shuffle: 'pos-shuffle' },
-      { stack: 'neg-stack', size: 'neg-stack-size', shuffle: 'neg-shuffle' }
+      { prefix: 'pos', stack: 'pos-stack', size: 'pos-stack-size', shuffle: 'pos-shuffle' },
+      { prefix: 'neg', stack: 'neg-stack', size: 'neg-stack-size', shuffle: 'neg-shuffle' }
     ];
     configs.forEach(cfg => {
       const stackCb = document.getElementById(cfg.stack);
@@ -236,8 +246,11 @@
           shuffleCb.checked = prev;
           sizeEl.style.display = 'none';
         }
+        const count = stackCb.checked ? parseInt(sizeEl.value, 10) || 1 : 1;
+        updateOrderContainers(cfg.prefix, count);
       };
       stackCb.addEventListener('change', update);
+      sizeEl.addEventListener('change', update);
       update();
     });
   }
@@ -309,6 +322,38 @@
       opt.textContent = o.title;
       select.appendChild(opt);
     });
+  }
+
+  function updateOrderContainers(prefix, count) {
+    const container = document.getElementById(`${prefix}-order-container`);
+    const baseId = `${prefix}-order`;
+    const getItems = () =>
+      utils.parseInput(document.getElementById(`${prefix}-input`).value);
+    if (!container) return;
+    const current = container.querySelectorAll('select').length;
+    for (let i = current; i < count; i++) {
+      const idx = i + 1;
+      const sel = document.createElement('select');
+      sel.id = `${baseId}-select-${idx}`;
+      populateOrderOptions(sel);
+      container.appendChild(sel);
+      const div = document.createElement('div');
+      div.className = 'input-row';
+      const ta = document.createElement('textarea');
+      ta.id = `${baseId}-input-${idx}`;
+      ta.rows = 1;
+      ta.placeholder = '0,1,2';
+      div.appendChild(ta);
+      container.appendChild(div);
+      setupOrderControl(sel.id, ta.id, getItems);
+    }
+    for (let i = current; i > count; i--) {
+      const idx = i;
+      const sel = document.getElementById(`${baseId}-select-${idx}`);
+      const ta = document.getElementById(`${baseId}-input-${idx}`);
+      if (sel) sel.remove();
+      if (ta && ta.parentElement) ta.parentElement.remove();
+    }
   }
 
   function setupOrderControl(selectId, inputId, getItems) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -419,6 +419,39 @@ describe('UI interactions', () => {
     utils.shuffle = orig;
     expect(document.getElementById('base-order-input').value).toBe('1, 0');
   });
+
+  test('rerollRandomOrders handles stacked order inputs', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input"></textarea>
+      <textarea id="pos-input">a,b</textarea>
+      <textarea id="neg-input"></textarea>
+      <textarea id="divider-input"></textarea>
+      <select id="pos-order-select">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-order-input"></textarea>
+      <select id="pos-order-select-2">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-order-input-2"></textarea>
+    `;
+    const orig = utils.shuffle;
+    utils.shuffle = jest.fn(arr => arr.reverse());
+    setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
+    setupOrderControl('pos-order-select-2', 'pos-order-input-2', () => ['a', 'b']);
+    document.getElementById('pos-order-select').value = 'random';
+    document.getElementById('pos-order-select').dispatchEvent(new Event('change'));
+    document.getElementById('pos-order-select-2').value = 'random';
+    document
+      .getElementById('pos-order-select-2')
+      .dispatchEvent(new Event('change'));
+    rerollRandomOrders();
+    utils.shuffle = orig;
+    expect(document.getElementById('pos-order-input').value).toBe('1, 0');
+    expect(document.getElementById('pos-order-input-2').value).toBe('1, 0');
+  });
 });
 
 describe('List persistence', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -231,6 +231,26 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'p1 p1 x', negative: 'n1 n1 x' });
   });
 
+  test('buildVersions applies separate orders per stack', () => {
+    const out = buildVersions(
+      ['x'],
+      ['n1', 'n2'],
+      ['p1', 'p2'],
+      20,
+      false,
+      [],
+      true,
+      2,
+      2,
+      null,
+      null,
+      [[0, 1], [1, 0]],
+      [[1, 0], [0, 1]]
+    );
+    expect(out.positive).toBe('p2 p1 x, p1 p2 x');
+    expect(out.negative).toBe('n1 n2 x, n2 n1 x');
+  });
+
   test('stacking works with natural dividers', () => {
     const out = buildVersions(
       ['a', 'b'],


### PR DESCRIPTION
## Summary
- allow multiple order controls when stacking mods
- dynamically manage order selectors based on stack size
- handle arrays of modifier orders
- add tests for multiple stack orders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868c1e60ec88321a0aee1186e32ca97