### PR TITLE
Improve stacking order support

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -123,9 +123,11 @@
           <div class="input-row">
             <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
           </div>
-          <select id="pos-order-select"></select>
-          <div class="input-row">
-            <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="pos-order-container">
+            <select id="pos-order-select"></select>
+            <div class="input-row">
+              <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+            </div>
           </div>
         </div>
         <!-- Negative modifier selection section -->
@@ -156,9 +158,11 @@
           <div class="input-row">
             <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
           </div>
-          <select id="neg-order-select"></select>
-          <div class="input-row">
-            <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="neg-order-container">
+            <select id="neg-order-select"></select>
+            <div class="input-row">
+              <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+            </div>
           </div>
         </div>
         <!-- Character length limit selection -->

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -143,15 +143,23 @@
     modifiers,
     limit,
     stackSize = 1,
-    modOrder = null,
+    modOrders = null,
     delimited = false,
     dividers = [],
     itemOrder = null,
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    const orderedMods = modOrder ? applyOrder(modifiers, modOrder) : modifiers.slice();
-    const orders = Array(count).fill(orderedMods);
+    const orders = [];
+    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+      for (let i = 0; i < count; i++) {
+        const ord = modOrders[i % modOrders.length];
+        orders.push(ord ? applyOrder(modifiers, ord) : modifiers.slice());
+      }
+    } else {
+      const orderedMods = modOrders ? applyOrder(modifiers, modOrders) : modifiers.slice();
+      for (let i = 0; i < count; i++) orders.push(orderedMods);
+    }
     const dividerPool = dividers.slice();
     let items = baseItems.slice();
     if (itemOrder) items = applyOrder(items, itemOrder);
@@ -189,15 +197,23 @@
     negMods,
     limit,
     stackSize = 1,
-    modOrder = null,
+    modOrders = null,
     delimited = false,
     dividers = [],
     itemOrder = null,
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
-    const orderedMods = modOrder ? applyOrder(negMods, modOrder) : negMods.slice();
-    const orders = Array(count).fill(orderedMods);
+    const orders = [];
+    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+      for (let i = 0; i < count; i++) {
+        const ord = modOrders[i % modOrders.length];
+        orders.push(ord ? applyOrder(negMods, ord) : negMods.slice());
+      }
+    } else {
+      const orderedMods = modOrders ? applyOrder(negMods, modOrders) : negMods.slice();
+      for (let i = 0; i < count; i++) orders.push(orderedMods);
+    }
     const dividerSet = new Set(dividers);
     const result = [];
     let modIdx = 0;
@@ -274,7 +290,7 @@
           negOrder,
           delimited,
           dividerPool,
-          baseOrder,
+          null,
           depths
         )
       : applyModifierStack(

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -231,6 +231,26 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'p1 p1 x', negative: 'n1 n1 x' });
   });
 
+  test('buildVersions applies separate orders per stack', () => {
+    const out = buildVersions(
+      ['x'],
+      ['n1', 'n2'],
+      ['p1', 'p2'],
+      20,
+      false,
+      [],
+      true,
+      2,
+      2,
+      null,
+      null,
+      [[0, 1], [1, 0]],
+      [[1, 0], [0, 1]]
+    );
+    expect(out.positive).toBe('p2 p1 x, p1 p2 x');
+    expect(out.negative).toBe('n1 n2 x, n2 n1 x');
+  });
+
   test('stacking works with natural dividers', () => {
     const out = buildVersions(
       ['a', 'b'],
@@ -259,6 +279,24 @@ describe('Prompt building', () => {
     );
     expect(out.positive).toBe('good cat, \nfoo , good cat, \nfoo ');
     expect(out.negative).toBe('bad good cat, \nfoo , bad good cat, \nfoo ');
+  });
+
+  test('random base order keeps negatives aligned', () => {
+    const out = buildVersions(
+      ['a', 'b'],
+      ['n'],
+      ['p'],
+      50,
+      true,
+      ['\nfoo '],
+      true,
+      1,
+      1,
+      null,
+      [1, 0]
+    );
+    const expectedNeg = out.positive.replace(/\bp /g, 'n p ');
+    expect(out.negative).toBe(expectedNeg);
   });
 });
 
@@ -398,6 +436,33 @@ describe('UI interactions', () => {
     rerollRandomOrders();
     utils.shuffle = orig;
     expect(document.getElementById('base-order-input').value).toBe('1, 0');
+  });
+
+  test('rerollRandomOrders handles multiple order controls', () => {
+    document.body.innerHTML = `
+      <select id="pos-order-select">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-order-input"></textarea>
+      <select id="pos-order-select-2">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-order-input-2"></textarea>
+      <textarea id="pos-input">a,b</textarea>
+    `;
+    const orig = utils.shuffle;
+    utils.shuffle = jest.fn(arr => {
+      arr.reverse();
+      return arr;
+    });
+    document.getElementById('pos-order-select').value = 'random';
+    document.getElementById('pos-order-select-2').value = 'random';
+    rerollRandomOrders();
+    utils.shuffle = orig;
+    expect(document.getElementById('pos-order-input').value).toBe('1, 0');
+    expect(document.getElementById('pos-order-input-2').value).toBe('1, 0');
   });
 });
 


### PR DESCRIPTION
## Summary
- allow multiple order controls when stacking mods
- dynamically manage order selectors based on stack size
- handle arrays of modifier orders
- add tests for multiple stack orders
- fix negative prompt alignment when base order randomized
- support rerolling random orders for all stack levels

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868c1e60ec88321a0aee1186e32ca97