### PR TITLE
Add simple/advanced mode toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,8 @@
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
             <input type="checkbox" id="all-random" hidden>
             <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+            <input type="checkbox" id="advanced-mode" hidden>
+            <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
           </div>
         </div>
         <div class="input-group">

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -306,6 +306,83 @@
     });
   }
 
+  function applyAdvancedMode() {
+    const advCb = document.getElementById('advanced-mode');
+    const advanced = advCb && advCb.checked;
+    const gather = prefix => {
+      const arr = [];
+      let idx = 1;
+      while (true) {
+        const sel = document.getElementById(
+          `${prefix}-order-select${idx === 1 ? '' : '-' + idx}`
+        );
+        const inp = document.getElementById(
+          `${prefix}-order-input${idx === 1 ? '' : '-' + idx}`
+        );
+        if (!sel || !inp) break;
+        arr.push(sel, inp);
+        idx++;
+      }
+      return arr;
+    };
+    const elems = [
+      ...gather('base'),
+      ...gather('pos'),
+      ...gather('neg'),
+      ...gather('divider'),
+      document.getElementById('insert-select'),
+      document.getElementById('insert-input')
+    ].filter(Boolean);
+    elems.forEach(el => {
+      el.style.display = advanced ? '' : 'none';
+    });
+    const buttons = [
+      'base-reroll',
+      'pos-reroll',
+      'neg-reroll',
+      'divider-reroll',
+      'insert-reroll'
+    ];
+    buttons.forEach(id => {
+      const b = document.getElementById(id);
+      if (b) b.style.display = advanced ? 'none' : '';
+    });
+    if (!advanced) {
+      const sync = (btnId, prefix) => {
+        const btn = document.getElementById(btnId);
+        if (!btn) return;
+        let idx = 1;
+        const active = btn.classList.contains('active');
+        while (true) {
+          const sel = document.getElementById(
+            `${prefix}-order-select${idx === 1 ? '' : '-' + idx}`
+          );
+          if (!sel) break;
+          sel.value = active ? 'random' : 'canonical';
+          sel.dispatchEvent(new Event('change'));
+          idx++;
+        }
+      };
+      sync('base-reroll', 'base');
+      sync('pos-reroll', 'pos');
+      sync('neg-reroll', 'neg');
+      sync('divider-reroll', 'divider');
+      const insBtn = document.getElementById('insert-reroll');
+      const insSel = document.getElementById('insert-select');
+      if (insBtn && insSel) {
+        insSel.value = insBtn.classList.contains('active') ? 'random' : 'canonical';
+        insSel.dispatchEvent(new Event('change'));
+      }
+    }
+  }
+
+  function setupAdvancedMode() {
+    const cb = document.getElementById('advanced-mode');
+    if (!cb) return;
+    cb.addEventListener('change', applyAdvancedMode);
+    applyAdvancedMode();
+  }
+
   function populateOrderOptions(select) {
     if (!select) return;
     select.innerHTML = '';
@@ -354,6 +431,7 @@
       if (sel) sel.remove();
       if (ta && ta.parentElement) ta.parentElement.remove();
     }
+    applyAdvancedMode();
   }
 
   function setupOrderControl(selectId, inputId, getItems) {
@@ -434,8 +512,18 @@
     const select = document.getElementById(selectId);
     if (!btn || !select) return;
     const reroll = () => {
-      if (select.value !== 'random') {
-        select.value = 'random';
+      const adv = document.getElementById('advanced-mode');
+      const simple = !adv || !adv.checked;
+      if (simple) {
+        if (btn.classList.contains('active')) {
+          select.value = 'canonical';
+        } else {
+          select.value = 'random';
+        }
+      } else {
+        if (select.value !== 'random') {
+          select.value = 'random';
+        }
       }
       select.dispatchEvent(new Event('change'));
     };
@@ -584,6 +672,7 @@
     setupToggleButtons();
     setupStackControls();
     setupShuffleAll();
+    setupAdvancedMode();
     const hideCheckboxes = setupHideToggles();
 
     const allHide = document.getElementById('all-hide');
@@ -653,6 +742,8 @@
     updateButtonState,
     setupToggleButtons,
     setupShuffleAll,
+    setupAdvancedMode,
+    applyAdvancedMode,
     setupStackControls,
     setupHideToggles,
     setupCopyButtons,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -31,7 +31,9 @@ const {
   applyPreset,
   setupOrderControl,
   setupRerollButton,
-  rerollRandomOrders
+  rerollRandomOrders,
+  setupAdvancedMode,
+  applyAdvancedMode
 } = ui;
 
 describe('Utility functions', () => {
@@ -463,6 +465,59 @@ describe('UI interactions', () => {
     utils.shuffle = orig;
     expect(document.getElementById('pos-order-input').value).toBe('1, 0');
     expect(document.getElementById('pos-order-input-2').value).toBe('1, 0');
+  });
+
+  test('advanced mode toggles visibility and reroll buttons', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <select id="base-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <textarea id="base-order-input"></textarea>
+      <button id="base-reroll" class="toggle-button random-button"></button>
+    `;
+    setupOrderControl('base-order-select', 'base-order-input', () => ['a']);
+    setupRerollButton('base-reroll', 'base-order-select');
+    setupAdvancedMode();
+    const cb = document.getElementById('advanced-mode');
+    const sel = document.getElementById('base-order-select');
+    const ta = document.getElementById('base-order-input');
+    const btn = document.getElementById('base-reroll');
+    expect(sel.style.display).toBe('none');
+    expect(ta.style.display).toBe('none');
+    expect(btn.style.display).toBe('');
+    btn.click();
+    expect(sel.value).toBe('random');
+    btn.click();
+    expect(sel.value).toBe('canonical');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(sel.style.display).toBe('');
+    expect(ta.style.display).toBe('');
+    expect(btn.style.display).toBe('none');
+  });
+
+  test('advanced mode hides multiple order controls', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <div id="pos-order-container">
+        <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-order-select-2"><option value="canonical">c</option><option value="random">r</option></select>
+        <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      </div>
+      <textarea id="pos-input"></textarea>
+      <button id="pos-reroll" class="toggle-button random-button"></button>
+    `;
+    setupRerollButton('pos-reroll', 'pos-order-select');
+    setupAdvancedMode();
+    const cb = document.getElementById('advanced-mode');
+    expect(document.getElementById('pos-order-select').style.display).toBe('none');
+    expect(document.getElementById('pos-order-select-2').style.display).toBe('none');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-order-input-2').style.display).toBe('');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-order-select').style.display).toBe('none');
   });
 });
 


### PR DESCRIPTION
## Summary
- add simple/advanced toggle under Quick Actions
- hide order controls in simple mode and sync reroll buttons
- hide reroll buttons in advanced mode
- implement setupAdvancedMode and applyAdvancedMode
- update tests for new mode behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868cc1b04a083219cc6d807eeb0018e