### PR TITLE
Add simple mode stack defaults

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,8 @@
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
             <input type="checkbox" id="all-random" hidden>
             <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+            <input type="checkbox" id="advanced-mode" hidden>
+            <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
           </div>
         </div>
         <div class="input-group">

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -255,6 +255,49 @@
     });
   }
 
+  function setupAdvancedToggle() {
+    const cb = document.getElementById('advanced-mode');
+    if (!cb) return;
+    const selectIds = [
+      'base-order-select',
+      'pos-order-select',
+      'neg-order-select',
+      'divider-order-select',
+      'insert-select'
+    ];
+    const textIds = [
+      'base-order-input',
+      'divider-order-input',
+      'insert-input'
+    ];
+    const containerIds = ['pos-order-container', 'neg-order-container'];
+    const rerollIds = [
+      'base-reroll',
+      'pos-reroll',
+      'neg-reroll',
+      'divider-reroll',
+      'insert-reroll'
+    ];
+    const setDisplay = (el, show) => {
+      if (!el) return;
+      el.style.display = show ? '' : 'none';
+    };
+    const update = () => {
+      const adv = cb.checked;
+      selectIds.forEach(id => setDisplay(document.getElementById(id), adv));
+      textIds.forEach(id => {
+        const el = document.getElementById(id);
+        if (el && el.parentElement && el.parentElement.classList.contains('input-row')) {
+          setDisplay(el.parentElement, adv);
+        }
+      });
+      containerIds.forEach(id => setDisplay(document.getElementById(id), adv));
+      rerollIds.forEach(id => setDisplay(document.getElementById(id), !adv));
+    };
+    cb.addEventListener('change', update);
+    update();
+  }
+
   function setupHideToggles() {
     const hideCheckboxes = Array.from(document.querySelectorAll('input[type="checkbox"][data-targets]'));
     hideCheckboxes.forEach(cb => {
@@ -331,11 +374,18 @@
       utils.parseInput(document.getElementById(`${prefix}-input`).value);
     if (!container) return;
     const current = container.querySelectorAll('select').length;
+    const adv = document.getElementById('advanced-mode');
+    const baseSelect = document.getElementById(`${baseId}-select`);
+    const simpleDefault =
+      baseSelect && baseSelect.value === 'random' ? 'random' : 'canonical';
     for (let i = current; i < count; i++) {
       const idx = i + 1;
       const sel = document.createElement('select');
       sel.id = `${baseId}-select-${idx}`;
       populateOrderOptions(sel);
+      if (!adv || !adv.checked) {
+        sel.value = simpleDefault;
+      }
       container.appendChild(sel);
       const div = document.createElement('div');
       div.className = 'input-row';
@@ -432,18 +482,28 @@
   function setupRerollButton(btnId, selectId) {
     const btn = document.getElementById(btnId);
     const select = document.getElementById(selectId);
+    const adv = document.getElementById('advanced-mode');
     if (!btn || !select) return;
     const reroll = () => {
-      if (select.value !== 'random') {
-        select.value = 'random';
+      const advanced = adv && adv.checked;
+      if (advanced) {
+        if (select.value !== 'random') {
+          select.value = 'random';
+        }
+      } else {
+        select.value = select.value === 'random' ? 'canonical' : 'random';
       }
       select.dispatchEvent(new Event('change'));
     };
     btn.addEventListener('click', reroll);
     const update = () => {
       btn.classList.toggle('active', select.value === 'random');
+      if (adv && adv.checked) {
+        btn.classList.remove('active');
+      }
     };
     select.addEventListener('change', update);
+    if (adv) adv.addEventListener('change', update);
     update();
   }
 
@@ -579,6 +639,7 @@
     setupRerollButton('neg-reroll', 'neg-order-select');
     setupRerollButton('divider-reroll', 'divider-order-select');
     setupRerollButton('insert-reroll', 'insert-select');
+    setupAdvancedToggle();
     document.getElementById('generate').addEventListener('click', generate);
 
     setupToggleButtons();
@@ -659,6 +720,9 @@
     setupDepthControls,
     setupStateButtons,
     setupOrderControl,
+    populateOrderOptions,
+    updateOrderContainers,
+    setupAdvancedToggle,
     rerollRandomOrders,
     setupRerollButton,
     initializeUI

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -31,7 +31,10 @@ const {
   applyPreset,
   setupOrderControl,
   setupRerollButton,
-  rerollRandomOrders
+  rerollRandomOrders,
+  setupAdvancedToggle,
+  populateOrderOptions,
+  updateOrderContainers
 } = ui;
 
 describe('Utility functions', () => {
@@ -463,6 +466,78 @@ describe('UI interactions', () => {
     utils.shuffle = orig;
     expect(document.getElementById('pos-order-input').value).toBe('1, 0');
     expect(document.getElementById('pos-order-input-2').value).toBe('1, 0');
+  });
+
+  test('advanced toggle shows and hides controls', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <select id="base-order-select"></select>
+      <div class="input-row"><textarea id="base-order-input"></textarea></div>
+      <div id="pos-order-container">
+        <select id="pos-order-select"></select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-order-select-2"></select>
+        <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      </div>
+      <button id="base-reroll"></button>
+    `;
+    setupAdvancedToggle();
+    const cb = document.getElementById('advanced-mode');
+    const select = document.getElementById('base-order-select');
+    const taRow = document.getElementById('base-order-input').parentElement;
+    const cont = document.getElementById('pos-order-container');
+    const btn = document.getElementById('base-reroll');
+
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(select.style.display).toBe('');
+    expect(taRow.style.display).toBe('');
+    expect(cont.style.display).toBe('');
+    expect(btn.style.display).toBe('none');
+
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(select.style.display).toBe('none');
+    expect(taRow.style.display).toBe('none');
+    expect(cont.style.display).toBe('none');
+    expect(btn.style.display).toBe('');
+  });
+
+  test('simple mode adds random orderings when dice active', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <div id="pos-order-container">
+        <select id="pos-order-select"></select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+      </div>
+      <textarea id="pos-input">a,b</textarea>
+    `;
+    populateOrderOptions(document.getElementById('pos-order-select'));
+    setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
+    document.getElementById('pos-order-select').value = 'random';
+    document.getElementById('pos-order-select').dispatchEvent(new Event('change'));
+    updateOrderContainers('pos', 2);
+    const sel2 = document.getElementById('pos-order-select-2');
+    const inp2 = document.getElementById('pos-order-input-2');
+    expect(sel2.value).toBe('random');
+    expect(inp2.value).toBe('');
+  });
+
+  test('advanced mode new orderings default to canonical', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <div id="pos-order-container">
+        <select id="pos-order-select"></select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+      </div>
+      <textarea id="pos-input">a,b</textarea>
+    `;
+    populateOrderOptions(document.getElementById('pos-order-select'));
+    setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
+    const adv = document.getElementById('advanced-mode');
+    adv.checked = true;
+    updateOrderContainers('pos', 2);
+    expect(document.getElementById('pos-order-select-2').value).toBe('canonical');
   });
 });
 


### PR DESCRIPTION
## Summary
- update `updateOrderContainers` to inherit random/canonical state in simple mode
- export helper functions for tests
- add tests for stack size behaviour when toggling advanced mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868cc1b04a083219cc6d807eeb0018e