### PR TITLE
Fix stack order defaults in simple mode

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,8 @@
             <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
             <input type="checkbox" id="all-random" hidden>
             <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+            <input type="checkbox" id="advanced-mode" hidden>
+            <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
           </div>
         </div>
         <div class="input-group">

--- a/src/style.css
+++ b/src/style.css
@@ -465,6 +465,17 @@ button {
   border-color: transparent;
 }
 
+.random-button.indeterminate {
+  background: repeating-linear-gradient(
+    45deg,
+    #0d6efd,
+    #0d6efd 5px,
+    #6610f2 5px,
+    #6610f2 10px
+  );
+  border-color: transparent;
+}
+
 .hide-button {
   font-size: 1rem;
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -31,7 +31,8 @@ const {
   applyPreset,
   setupOrderControl,
   setupRerollButton,
-  rerollRandomOrders
+  rerollRandomOrders,
+  setupAdvancedToggle
 } = ui;
 
 describe('Utility functions', () => {
@@ -463,6 +464,131 @@ describe('UI interactions', () => {
     utils.shuffle = orig;
     expect(document.getElementById('pos-order-input').value).toBe('1, 0');
     expect(document.getElementById('pos-order-input-2').value).toBe('1, 0');
+  });
+
+  test('advanced toggle shows and hides controls', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <select id="base-order-select"></select>
+      <div class="input-row"><textarea id="base-order-input"></textarea></div>
+      <div id="pos-order-container">
+        <select id="pos-order-select">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-order-select-2">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      </div>
+      <button id="base-reroll"></button>
+    `;
+    setupAdvancedToggle();
+    const cb = document.getElementById('advanced-mode');
+    const select = document.getElementById('base-order-select');
+    const taRow = document.getElementById('base-order-input').parentElement;
+    const cont = document.getElementById('pos-order-container');
+    const btn = document.getElementById('base-reroll');
+
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(select.style.display).toBe('');
+    expect(taRow.style.display).toBe('');
+    expect(cont.style.display).toBe('');
+    expect(btn.style.display).toBe('none');
+
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(select.style.display).toBe('none');
+    expect(taRow.style.display).toBe('none');
+    expect(cont.style.display).toBe('none');
+    expect(btn.style.display).toBe('');
+  });
+
+  test('new stack order uses reroll state in simple mode', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <div id="pos-order-container">
+        <select id="pos-order-select">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+      </div>
+      <button id="pos-reroll"></button>
+      <textarea id="pos-input">a,b</textarea>
+    `;
+    setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
+    setupRerollButton('pos-reroll', 'pos-order-select');
+    setupStackControls();
+    document.getElementById('pos-reroll').click();
+    const stackCb = document.getElementById('pos-stack');
+    stackCb.checked = true;
+    stackCb.dispatchEvent(new Event('change'));
+    const sel2 = document.getElementById('pos-order-select-2');
+    const ta2 = document.getElementById('pos-order-input-2');
+    expect(sel2.value).toBe('random');
+    expect(ta2.value).toBe('');
+  });
+
+  test('reroll button syncs state on mode switch', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <div id="pos-order-container">
+        <select id="pos-order-select">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-order-select-2">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      </div>
+      <button id="pos-reroll" class="random-button"></button>
+    `;
+    document.getElementById('pos-order-select').value = 'random';
+    document.getElementById('pos-order-select-2').value = 'canonical';
+    setupRerollButton('pos-reroll', 'pos-order-select');
+    setupAdvancedToggle();
+    const cb = document.getElementById('advanced-mode');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    const btn = document.getElementById('pos-reroll');
+    expect(btn.classList.contains('indeterminate')).toBe(true);
+  });
+
+  test('simple mode reroll toggles all selects', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <div id="neg-order-container">
+        <select id="neg-order-select">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="neg-order-input"></textarea></div>
+        <select id="neg-order-select-2">
+          <option value="canonical">c</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="neg-order-input-2"></textarea></div>
+      </div>
+      <button id="neg-reroll" class="random-button"></button>
+    `;
+    setupRerollButton('neg-reroll', 'neg-order-select');
+    setupAdvancedToggle();
+    const cb = document.getElementById('advanced-mode');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    document.getElementById('neg-reroll').click();
+    expect(document.getElementById('neg-order-select').value).toBe('random');
+    expect(document.getElementById('neg-order-select-2').value).toBe('random');
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure new order controls inherit reroll state when in simple mode
- add advanced/simple toggle logic for reroll buttons
- apply gradient style when orderings mixed
- expand tests for reroll behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868cc1b04a083219cc6d807eeb0018e