### PR TITLE
Add per-list insertion depth controls

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
               <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
               <button type="button" id="divider-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
               <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
-              <input type="checkbox" id="divider-hide" data-targets="divider-input,divider-order-input" hidden>
+              <input type="checkbox" id="divider-hide" data-targets="divider-input,divider-order-input,divider-depth-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -76,6 +76,10 @@
           <div class="input-row">
             <textarea id="divider-order-input" rows="1" placeholder="0,1,2"></textarea>
           </div>
+          <select id="divider-depth-select"></select>
+          <div class="input-row">
+            <textarea id="divider-depth-input" rows="1" placeholder="0"></textarea>
+          </div>
         </div>
         <!-- Base prompt input section -->
         <div class="input-group">
@@ -86,7 +90,7 @@
               <button type="button" id="base-save" class="save-button icon-button" title="Save">&#128190;</button>
               <button type="button" id="base-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
               <button type="button" class="copy-button icon-button" data-target="base-input" title="Copy">&#128203;</button>
-              <input type="checkbox" id="base-hide" data-targets="base-input,base-order-input" hidden>
+              <input type="checkbox" id="base-hide" data-targets="base-input,base-order-input,base-depth-input" hidden>
               <button type="button" class="toggle-button icon-button hide-button" data-target="base-hide" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -97,6 +101,10 @@
           <select id="base-order-select"></select>
           <div class="input-row">
             <textarea id="base-order-input" rows="1" placeholder="0,1,2"></textarea>
+          </div>
+          <select id="base-depth-select"></select>
+          <div class="input-row">
+            <textarea id="base-depth-input" rows="1" placeholder="0"></textarea>
           </div>
         </div>
         <!-- Positive modifier selection section -->
@@ -110,7 +118,7 @@
                 <button type="button" id="pos-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" id="pos-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
                 <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
-                <input type="checkbox" id="pos-hide" data-targets="pos-input,pos-order-input" hidden>
+                <input type="checkbox" id="pos-hide" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide" data-on="☰" data-off="✖">☰</button>
               </div>
           </div>
@@ -130,6 +138,10 @@
             <div class="input-row">
               <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
             </div>
+            <select id="pos-depth-select"></select>
+            <div class="input-row">
+              <textarea id="pos-depth-input" rows="1" placeholder="0"></textarea>
+            </div>
           </div>
         </div>
         <!-- Negative modifier selection section -->
@@ -145,7 +157,7 @@
                 <button type="button" id="neg-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" id="neg-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
                 <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
-                <input type="checkbox" id="neg-hide" data-targets="neg-input,neg-order-input" hidden>
+                <input type="checkbox" id="neg-hide" data-targets="neg-input,neg-order-input,neg-depth-input" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide" data-on="☰" data-off="✖">☰</button>
               </div>
           </div>
@@ -165,6 +177,10 @@
             <div class="input-row">
               <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
             </div>
+            <select id="neg-depth-select"></select>
+            <div class="input-row">
+              <textarea id="neg-depth-input" rows="1" placeholder="0"></textarea>
+            </div>
           </div>
         </div>
         <!-- Character length limit selection -->
@@ -183,22 +199,6 @@
         </select>
       <div class="input-row">
         <input type="number" id="length-input" value="1000" min="1">
-      </div>
-    </div>
-    <div class="input-group">
-      <div class="label-row">
-        <label for="insert-input">Insertion Depths</label>
-        <div class="button-col">
-          <button type="button" id="insert-save" class="save-button icon-button" title="Save">&#128190;</button>
-          <button type="button" id="insert-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
-          <button type="button" class="copy-button icon-button" data-target="insert-input" title="Copy">&#128203;</button>
-          <input type="checkbox" id="insert-hide" data-targets="insert-input" hidden>
-          <button type="button" class="toggle-button icon-button hide-button" data-target="insert-hide" data-on="☰" data-off="✖">☰</button>
-        </div>
-      </div>
-      <select id="insert-select"></select>
-      <div class="input-row">
-        <textarea id="insert-input" rows="2" placeholder="0,1,2"></textarea>
       </div>
     </div>
     <!-- Lyrics processing input -->

--- a/src/listManager.js
+++ b/src/listManager.js
@@ -95,8 +95,6 @@
     if (baseSelect) populateSelect(baseSelect, base);
     const lyricsSelect = document.getElementById('lyrics-select');
     if (lyricsSelect) populateSelect(lyricsSelect, lyrics);
-    const orderSelect = document.getElementById('insert-select');
-    if (orderSelect) populateSelect(orderSelect, order);
   }
 
   function exportLists() {
@@ -169,8 +167,7 @@
       positive: { select: 'pos-select', input: 'pos-input', store: POS_PRESETS },
       length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
       divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
-      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS },
-      order: { select: 'insert-select', input: 'insert-input', store: ORDER_PRESETS }
+      lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS }
     };
     const cfg = map[type];
     if (!cfg) return;

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -256,7 +256,8 @@
     shuffleDividers = true,
     posStackSize = 1,
     negStackSize = 1,
-    depths = null,
+    posDepths = null,
+    negDepths = null,
     baseOrder = null,
     posOrder = null,
     negOrder = null,
@@ -279,7 +280,7 @@
       delimited,
       dividerPool,
       baseOrder,
-      depths
+      posDepths
     );
     const negTerms = includePosForNeg
       ? applyNegativeOnPositive(
@@ -291,7 +292,7 @@
           delimited,
           dividerPool,
           null,
-          depths
+          negDepths
         )
       : applyModifierStack(
           items,
@@ -302,7 +303,7 @@
           delimited,
           dividerPool,
           baseOrder,
-          depths
+          negDepths
         );
     const [trimNeg, trimPos] = equalizeLength(negTerms, posTerms);
     return {

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -42,16 +42,22 @@
     'lyrics-space',
     'lyrics-remove-parens',
     'lyrics-remove-brackets',
-    'insert-input',
-    'insert-select',
+    'base-depth-input',
+    'base-depth-select',
     'base-order-input',
     'base-order-select',
     'pos-order-input',
     'pos-order-select',
     'neg-order-input',
     'neg-order-select',
+    'pos-depth-input',
+    'pos-depth-select',
+    'neg-depth-input',
+    'neg-depth-select',
     'divider-order-input',
-    'divider-order-select'
+    'divider-order-select',
+    'divider-depth-input',
+    'divider-depth-select'
   ];
 
   function loadFromDOM() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -245,6 +245,7 @@ describe('Prompt building', () => {
       2,
       null,
       null,
+      null,
       [[0, 1], [1, 0]],
       [[1, 0], [0, 1]]
     );
@@ -293,6 +294,7 @@ describe('Prompt building', () => {
       true,
       1,
       1,
+      null,
       null,
       [1, 0]
     );
@@ -353,9 +355,13 @@ describe('UI interactions', () => {
   test('order all toggles dropdown values', () => {
     document.body.innerHTML = `
       <select id="base-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="base-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
       <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
       <select id="neg-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="neg-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
       <select id="divider-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="divider-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
       <input type="checkbox" id="all-random">
       <button class="toggle-button" data-target="all-random"></button>
     `;
@@ -404,6 +410,8 @@ describe('UI interactions', () => {
         <option value="random">r</option>
       </select>
       <textarea id="base-order-input"></textarea>
+      <select id="base-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+      <textarea id="base-depth-input"></textarea>
       <button id="base-reroll" class="toggle-button random-button" data-select="base-order-select"></button>
     `;
     const orig = utils.shuffle;
@@ -424,6 +432,8 @@ describe('UI interactions', () => {
         <option value="random">r</option>
       </select>
       <textarea id="base-order-input"></textarea>
+      <select id="base-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+      <textarea id="base-depth-input"></textarea>
       <textarea id="base-input">a,b</textarea>
     `;
     const orig = utils.shuffle;
@@ -446,11 +456,21 @@ describe('UI interactions', () => {
         <option value="random">r</option>
       </select>
       <textarea id="pos-order-input"></textarea>
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
       <select id="pos-order-select-2">
         <option value="canonical">c</option>
         <option value="random">r</option>
       </select>
       <textarea id="pos-order-input-2"></textarea>
+      <select id="pos-depth-select-2">
+        <option value="prepend">p</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-depth-input-2"></textarea>
       <textarea id="pos-input">a,b</textarea>
     `;
     const orig = utils.shuffle;
@@ -477,11 +497,16 @@ describe('UI interactions', () => {
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="pos-order-input"></textarea></div>
-        <select id="pos-order-select-2">
-          <option value="canonical">c</option>
-          <option value="random">r</option>
-        </select>
-        <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      <select id="pos-order-select-2">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      <select id="pos-depth-select-2">
+        <option value="prepend">p</option>
+        <option value="random">r</option>
+      </select>
+      <div class="input-row"><textarea id="pos-depth-input-2"></textarea></div>
       </div>
       <button id="base-reroll"></button>
     `;
@@ -519,9 +544,15 @@ describe('UI interactions', () => {
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-depth-select">
+          <option value="prepend">p</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       </div>
       <button id="pos-reroll"></button>
       <textarea id="pos-input">a,b</textarea>
+      <textarea id="base-input">base</textarea>
     `;
     setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
     setupRerollButton('pos-reroll', 'pos-order-select');
@@ -545,13 +576,24 @@ describe('UI interactions', () => {
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        <select id="pos-depth-select">
+          <option value="prepend">p</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
         <select id="pos-order-select-2">
           <option value="canonical">c</option>
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+        <select id="pos-depth-select-2">
+          <option value="prepend">p</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="pos-depth-input-2"></textarea></div>
       </div>
       <button id="pos-reroll" class="random-button"></button>
+      <textarea id="base-input">base</textarea>
     `;
     document.getElementById('pos-order-select').value = 'random';
     document.getElementById('pos-order-select-2').value = 'canonical';
@@ -573,13 +615,24 @@ describe('UI interactions', () => {
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="neg-order-input"></textarea></div>
+        <select id="neg-depth-select">
+          <option value="prepend">p</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="neg-depth-input"></textarea></div>
         <select id="neg-order-select-2">
           <option value="canonical">c</option>
           <option value="random">r</option>
         </select>
         <div class="input-row"><textarea id="neg-order-input-2"></textarea></div>
+        <select id="neg-depth-select-2">
+          <option value="prepend">p</option>
+          <option value="random">r</option>
+        </select>
+        <div class="input-row"><textarea id="neg-depth-input-2"></textarea></div>
       </div>
       <button id="neg-reroll" class="random-button"></button>
+      <textarea id="base-input">base</textarea>
     `;
     setupRerollButton('neg-reroll', 'neg-order-select');
     setupAdvancedToggle();

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -34,8 +34,14 @@ function setupDOM() {
     <input type="checkbox" id="divider-shuffle">
     <select id="divider-order-select"></select>
     <textarea id="divider-order-input"></textarea>
-    <select id="insert-select"></select>
-    <textarea id="insert-input"></textarea>
+    <select id="base-depth-select"></select>
+    <textarea id="base-depth-input"></textarea>
+    <select id="pos-depth-select"></select>
+    <textarea id="pos-depth-input"></textarea>
+    <select id="neg-depth-select"></select>
+    <textarea id="neg-depth-input"></textarea>
+    <select id="divider-depth-select"></select>
+    <textarea id="divider-depth-input"></textarea>
     <select id="length-select"></select>
     <input id="length-input">
     <select id="lyrics-select"></select>


### PR DESCRIPTION
## Summary
- remove global insertion depth section from UI
- add depth select/input alongside each ordering control
- support stacked depth controls
- adjust state manager and list manager
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868d7f34f8883218a81133369cfbbad