### PR TITLE
Add multi-list stacking

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -85,8 +85,14 @@
     }
     const negSelect = document.getElementById('neg-select');
     if (negSelect) populateSelect(negSelect, neg);
+    document
+      .querySelectorAll('select[id^="neg-select-"]')
+      .forEach(sel => populateSelect(sel, neg));
     const posSelect = document.getElementById('pos-select');
     if (posSelect) populateSelect(posSelect, pos);
+    document
+      .querySelectorAll('select[id^="pos-select-"]')
+      .forEach(sel => populateSelect(sel, pos));
     const lengthSelect = document.getElementById('length-select');
     if (lengthSelect) populateSelect(lengthSelect, len);
     const dividerSelect = document.getElementById('divider-select');

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -149,9 +149,21 @@
     itemOrder = null,
     depths = null
   ) {
-    const count = stackSize > 0 ? stackSize : 1;
+    const usingStacks = Array.isArray(modifiers[0]);
+    const count = usingStacks ? modifiers.length : stackSize > 0 ? stackSize : 1;
     const orders = [];
-    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+    if (usingStacks) {
+      for (let i = 0; i < count; i++) {
+        const mods = modifiers[i % modifiers.length] || [];
+        let ord = null;
+        if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+          ord = modOrders[i % modOrders.length];
+        } else {
+          ord = modOrders;
+        }
+        orders.push(ord ? applyOrder(mods, ord) : mods.slice());
+      }
+    } else if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
       for (let i = 0; i < count; i++) {
         const ord = modOrders[i % modOrders.length];
         orders.push(ord ? applyOrder(modifiers, ord) : modifiers.slice());
@@ -203,9 +215,21 @@
     itemOrder = null,
     depths = null
   ) {
-    const count = stackSize > 0 ? stackSize : 1;
+    const usingStacks = Array.isArray(negMods[0]);
+    const count = usingStacks ? negMods.length : stackSize > 0 ? stackSize : 1;
     const orders = [];
-    if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+    if (usingStacks) {
+      for (let i = 0; i < count; i++) {
+        const mods = negMods[i % negMods.length] || [];
+        let ord = null;
+        if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
+          ord = modOrders[i % modOrders.length];
+        } else {
+          ord = modOrders;
+        }
+        orders.push(ord ? applyOrder(mods, ord) : mods.slice());
+      }
+    } else if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
       for (let i = 0; i < count; i++) {
         const ord = modOrders[i % modOrders.length];
         orders.push(ord ? applyOrder(negMods, ord) : negMods.slice());
@@ -274,7 +298,7 @@
       items,
       posMods,
       limit,
-      posStackSize,
+      Array.isArray(posMods[0]) ? posMods.length : posStackSize,
       posOrder,
       delimited,
       dividerPool,
@@ -286,7 +310,7 @@
           posTerms,
           negMods,
           limit,
-          negStackSize,
+          Array.isArray(negMods[0]) ? negMods.length : negStackSize,
           negOrder,
           delimited,
           dividerPool,
@@ -297,7 +321,7 @@
           items,
           negMods,
           limit,
-          negStackSize,
+          Array.isArray(negMods[0]) ? negMods.length : negStackSize,
           negOrder,
           delimited,
           dividerPool,

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -45,16 +45,29 @@
 
   function collectInputs() {
     const baseItems = utils.parseInput(document.getElementById('base-input').value, true);
-    const negMods = utils.parseInput(document.getElementById('neg-input').value);
-    const posMods = utils.parseInput(document.getElementById('pos-input').value);
-    const shuffleBase = document.getElementById('base-shuffle').checked;
-    const shufflePos = document.getElementById('pos-shuffle').checked;
+    const parseMods = (prefix, stackOn, size, presets, inputId) => {
+      const first = utils.parseInput(document.getElementById(inputId).value);
+      if (!stackOn) return first;
+      const arr = [first];
+      for (let i = 2; i <= size; i++) {
+        const sel = document.getElementById(`${prefix}-select-${i}`);
+        const preset = presets[sel?.value] || [];
+        arr.push(preset.slice());
+      }
+      return arr;
+    };
+
     const posStackOn = document.getElementById('pos-stack').checked;
     const posStackSize = parseInt(document.getElementById('pos-stack-size')?.value || '1', 10);
-    const includePosForNeg = document.getElementById('neg-include-pos').checked;
-    const shuffleNeg = document.getElementById('neg-shuffle').checked;
     const negStackOn = document.getElementById('neg-stack').checked;
     const negStackSize = parseInt(document.getElementById('neg-stack-size')?.value || '1', 10);
+
+    const negMods = parseMods('neg', negStackOn, negStackSize, lists.NEG_PRESETS, 'neg-input');
+    const posMods = parseMods('pos', posStackOn, posStackSize, lists.POS_PRESETS, 'pos-input');
+    const shuffleBase = document.getElementById('base-shuffle').checked;
+    const shufflePos = document.getElementById('pos-shuffle').checked;
+    const includePosForNeg = document.getElementById('neg-include-pos').checked;
+    const shuffleNeg = document.getElementById('neg-shuffle').checked;
     const dividerMods = utils.parseDividerInput(document.getElementById('divider-input')?.value || '');
     const shuffleDividers = document.getElementById('divider-shuffle')?.checked;
     const lengthSelect = document.getElementById('length-select');
@@ -248,6 +261,7 @@
         const count = stackCb.checked ? parseInt(sizeEl.value, 10) || 1 : 1;
         updateOrderContainers(cfg.prefix, count);
         updateDepthContainers(cfg.prefix, count);
+        updateListSelectors(cfg.prefix, count);
       };
       stackCb.addEventListener('change', update);
       sizeEl.addEventListener('change', update);
@@ -516,6 +530,24 @@
       const ta = document.getElementById(`${baseId}-input-${idx}`);
       if (sel) sel.remove();
       if (ta && ta.parentElement) ta.parentElement.remove();
+    }
+  }
+
+  function updateListSelectors(prefix, count) {
+    const base = document.getElementById(`${prefix}-select`);
+    if (!base) return;
+    const container = base.parentElement;
+    const existing = container.querySelectorAll(`select[id^="${prefix}-select-"]`).length + 1;
+    for (let i = existing; i < count; i++) {
+      const idx = i + 1;
+      const sel = base.cloneNode(true);
+      sel.id = `${prefix}-select-${idx}`;
+      container.appendChild(sel);
+    }
+    for (let i = existing; i > count; i--) {
+      const idx = i;
+      const sel = document.getElementById(`${prefix}-select-${idx}`);
+      if (sel) sel.remove();
     }
   }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -232,6 +232,11 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'p1 p1 x', negative: 'n1 n1 x' });
   });
 
+  test('buildVersions handles different lists per stack', () => {
+    const out = buildVersions(['x'], [], [['a'], ['b']], 50, false, [], true, 2, 1);
+    expect(out.positive.startsWith('b a x')).toBe(true);
+  });
+
   test('buildVersions applies separate orders per stack', () => {
     const out = buildVersions(
       ['x'],


### PR DESCRIPTION
## Summary
- support additional stacked list selectors when stacking is enabled
- allow `buildVersions` to use distinct lists per stack
- export helper for updating stacked list selectors
- test stacking with different lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868e08435048321bea0f7c3b48439af