### PR TITLE
Enable unique lists per stack

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -119,28 +119,32 @@
             <option value="3">3</option>
             <option value="4">4</option>
           </select>
-          <select id="pos-select">
-            <!-- Options will be populated dynamically from POSITIVE_LISTS -->
-          </select>
-          <div class="input-row">
-            <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
-          </div>
-          <div id="pos-order-container">
-            <div class="label-row">
-              <label for="pos-order-input">Positive Ordering</label>
-            </div>
-            <select id="pos-order-select"></select>
-            <div class="input-row">
-              <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
-            </div>
-          </div>
-          <div id="pos-depth-container">
-            <div class="label-row">
-              <label for="pos-depth-input">Positive Depth</label>
-            </div>
-            <select id="pos-depth-select"></select>
-            <div class="input-row">
-              <textarea id="pos-depth-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="pos-stack-container">
+            <div class="stack-block" id="pos-stack-1">
+              <select id="pos-select">
+                <!-- Options will be populated dynamically from POSITIVE_LISTS -->
+              </select>
+              <div class="input-row">
+                <textarea id="pos-input" rows="2" placeholder="Positive modifiers"></textarea>
+              </div>
+              <div id="pos-order-container">
+                <div class="label-row">
+                  <label for="pos-order-input">Positive Ordering</label>
+                </div>
+                <select id="pos-order-select"></select>
+                <div class="input-row">
+                  <textarea id="pos-order-input" rows="1" placeholder="0,1,2"></textarea>
+                </div>
+              </div>
+              <div id="pos-depth-container">
+                <div class="label-row">
+                  <label for="pos-depth-input">Positive Depth</label>
+                </div>
+                <select id="pos-depth-select"></select>
+                <div class="input-row">
+                  <textarea id="pos-depth-input" rows="1" placeholder="0,1,2"></textarea>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -166,28 +170,32 @@
             <option value="3">3</option>
             <option value="4">4</option>
           </select>
-          <select id="neg-select">
-            <!-- Options will be populated dynamically from NEGATIVE_LISTS -->
-          </select>
-          <div class="input-row">
-            <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
-          </div>
-          <div id="neg-order-container">
-            <div class="label-row">
-              <label for="neg-order-input">Negative Ordering</label>
-            </div>
-            <select id="neg-order-select"></select>
-            <div class="input-row">
-              <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
-            </div>
-          </div>
-          <div id="neg-depth-container">
-            <div class="label-row">
-              <label for="neg-depth-input">Negative Depth</label>
-            </div>
-            <select id="neg-depth-select"></select>
-            <div class="input-row">
-              <textarea id="neg-depth-input" rows="1" placeholder="0,1,2"></textarea>
+          <div id="neg-stack-container">
+            <div class="stack-block" id="neg-stack-1">
+              <select id="neg-select">
+                <!-- Options will be populated dynamically from NEGATIVE_LISTS -->
+              </select>
+              <div class="input-row">
+                <textarea id="neg-input" rows="3" placeholder="Negative modifiers"></textarea>
+              </div>
+              <div id="neg-order-container">
+                <div class="label-row">
+                  <label for="neg-order-input">Negative Ordering</label>
+                </div>
+                <select id="neg-order-select"></select>
+                <div class="input-row">
+                  <textarea id="neg-order-input" rows="1" placeholder="0,1,2"></textarea>
+                </div>
+              </div>
+              <div id="neg-depth-container">
+                <div class="label-row">
+                  <label for="neg-depth-input">Negative Depth</label>
+                </div>
+                <select id="neg-depth-select"></select>
+                <div class="input-row">
+                  <textarea id="neg-depth-input" rows="1" placeholder="0,1,2"></textarea>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/promptUtils.js
+++ b/src/promptUtils.js
@@ -150,15 +150,20 @@
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
+    const modLists = Array.isArray(modifiers[0]) ? modifiers : Array(count).fill(modifiers);
     const orders = [];
     if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
       for (let i = 0; i < count; i++) {
+        const mods = modLists[i % modLists.length];
         const ord = modOrders[i % modOrders.length];
-        orders.push(ord ? applyOrder(modifiers, ord) : modifiers.slice());
+        orders.push(ord ? applyOrder(mods, ord) : mods.slice());
       }
     } else {
-      const orderedMods = modOrders ? applyOrder(modifiers, modOrders) : modifiers.slice();
-      for (let i = 0; i < count; i++) orders.push(orderedMods);
+      for (let i = 0; i < count; i++) {
+        const mods = modLists[i % modLists.length];
+        const orderedMods = modOrders ? applyOrder(mods, modOrders) : mods.slice();
+        orders.push(orderedMods);
+      }
     }
     const dividerPool = dividers.slice();
     let items = baseItems.slice();
@@ -204,15 +209,20 @@
     depths = null
   ) {
     const count = stackSize > 0 ? stackSize : 1;
+    const modLists = Array.isArray(negMods[0]) ? negMods : Array(count).fill(negMods);
     const orders = [];
     if (Array.isArray(modOrders) && Array.isArray(modOrders[0])) {
       for (let i = 0; i < count; i++) {
+        const mods = modLists[i % modLists.length];
         const ord = modOrders[i % modOrders.length];
-        orders.push(ord ? applyOrder(negMods, ord) : negMods.slice());
+        orders.push(ord ? applyOrder(mods, ord) : mods.slice());
       }
     } else {
-      const orderedMods = modOrders ? applyOrder(negMods, modOrders) : negMods.slice();
-      for (let i = 0; i < count; i++) orders.push(orderedMods);
+      for (let i = 0; i < count; i++) {
+        const mods = modLists[i % modLists.length];
+        const orderedMods = modOrders ? applyOrder(mods, modOrders) : mods.slice();
+        orders.push(orderedMods);
+      }
     }
     const dividerSet = new Set(dividers);
     const result = [];

--- a/src/style.css
+++ b/src/style.css
@@ -530,3 +530,7 @@ button {
     font-family: inherit;
     margin-bottom: 1rem;
 }
+
+.stack-block {
+  margin-bottom: 1rem;
+}

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -252,6 +252,22 @@ describe('Prompt building', () => {
     expect(out.negative).toBe('n1 n2 x, n2 n1 x');
   });
 
+  test('buildVersions accepts different lists per stack', () => {
+    const out = buildVersions(
+      ['x'],
+      [['n1'], ['n2']],
+      [['p1'], ['p2']],
+      20,
+      false,
+      [],
+      true,
+      2,
+      2
+    );
+    expect(out.positive).toBe('p2 p1 x, p2 p1 x');
+    expect(out.negative).toBe('n2 n1 x, n2 n1 x');
+  });
+
   test('stacking works with natural dividers', () => {
     const out = buildVersions(
       ['a', 'b'],
@@ -513,15 +529,19 @@ describe('UI interactions', () => {
       <input type="checkbox" id="pos-stack">
       <select id="pos-stack-size"><option value="2">2</option></select>
       <input type="checkbox" id="pos-shuffle">
-      <div id="pos-order-container">
-        <select id="pos-order-select">
-          <option value="canonical">c</option>
-          <option value="random">r</option>
-        </select>
-        <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div id="pos-order-container">
+            <select id="pos-order-select">
+              <option value="canonical">c</option>
+              <option value="random">r</option>
+            </select>
+            <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+          </div>
+          <textarea id="pos-input">a,b</textarea>
+        </div>
       </div>
       <button id="pos-reroll"></button>
-      <textarea id="pos-input">a,b</textarea>
     `;
     setupOrderControl('pos-order-select', 'pos-order-input', () => ['a', 'b']);
     setupRerollButton('pos-reroll', 'pos-order-select');


### PR DESCRIPTION
## Summary
- allow `applyModifierStack` and `applyNegativeOnPositive` to accept arrays of modifier lists
- collect stacked inputs for list contents, orders and depths
- render list/order/depth controls within per-stack blocks in the UI
- adjust advanced-mode visibility logic for dynamic ids
- add `.stack-block` styling
- update tests for stacked list behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868e08435048321bea0f7c3b48439af