### PR TITLE
Fix global shuffle update for stacked dropdowns

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -223,7 +223,7 @@
       sel.id.includes('-depth-select') ? 'prepend' : 'canonical';
     const updateAll = () => {
       const selects = Array.from(
-        document.querySelectorAll('[id$="-order-select"], [id$="-depth-select"]')
+        document.querySelectorAll('[id*="-order-select"], [id*="-depth-select"]')
       );
       selects.forEach(sel => {
         sel.value = allRandom.checked ? 'random' : canonicalFor(sel);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -389,6 +389,31 @@ describe('UI interactions', () => {
     expect(document.getElementById('divider-order-select').value).toBe('canonical');
   });
 
+  test('order all also affects stacked dropdowns', () => {
+    document.body.innerHTML = `
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="pos-order-select-2"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="neg-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+      <select id="neg-depth-select-2"><option value="prepend">p</option><option value="random">r</option></select>
+      <input type="checkbox" id="all-random">
+      <button class="toggle-button" data-target="all-random"></button>
+    `;
+    setupShuffleAll();
+    const cb = document.getElementById('all-random');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-order-select').value).toBe('random');
+    expect(document.getElementById('pos-order-select-2').value).toBe('random');
+    expect(document.getElementById('neg-depth-select').value).toBe('random');
+    expect(document.getElementById('neg-depth-select-2').value).toBe('random');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-order-select').value).toBe('canonical');
+    expect(document.getElementById('pos-order-select-2').value).toBe('canonical');
+    expect(document.getElementById('neg-depth-select').value).toBe('prepend');
+    expect(document.getElementById('neg-depth-select-2').value).toBe('prepend');
+  });
+
   test('hide toggle does not hide sibling buttons', () => {
     document.body.innerHTML = `
       <div class="input-row">


### PR DESCRIPTION
## Summary
- fix `setupShuffleAll` to update dropdowns created via stacking
- test all-random toggle with stacked selects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868f92db4bc83218976c36139dc62d6