### PR TITLE
Fix negative depth with positive mods

### DIFF
--- a/src/lib/promptUtils.js
+++ b/src/lib/promptUtils.js
@@ -291,6 +291,10 @@
       baseOrder,
       depths
     );
+    let negDepths = depths;
+    if (includePosForNeg && Array.isArray(depths) && posStackSize > 0) {
+      negDepths = depths.map(d => (d > 0 ? d + posStackSize : d));
+    }
     const negTerms = includePosForNeg
       ? applyNegativeOnPositive(
           posTerms,
@@ -301,7 +305,7 @@
           delimited,
           dividerPool,
           null,
-          depths
+          negDepths
         )
       : applyModifierStack(
           items,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -138,6 +138,11 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
   });
 
+  test('buildVersions offsets depth for negatives when positives included', () => {
+    const out = buildVersions(['cat'], ['bad'], ['good'], 20, true, [], true, 1, 1, [1]);
+    expect(out).toEqual({ positive: 'cat good', negative: 'cat good bad' });
+  });
+
   test('buildVersions returns empty strings when items list is empty', () => {
     const out = buildVersions([], ['n'], ['p'], 10);
     expect(out).toEqual({ positive: '', negative: '' });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -143,6 +143,22 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'cat good', negative: 'cat good bad' });
   });
 
+  test('buildVersions respects per-stack depths', () => {
+    const out = buildVersions(
+      ['cat dog'],
+      [],
+      [['p1'], ['p2']],
+      20,
+      false,
+      [],
+      true,
+      2,
+      1,
+      [[1], [3]]
+    );
+    expect(out).toEqual({ positive: 'cat p1 dog p2', negative: 'cat dog' });
+  });
+
   test('buildVersions returns empty strings when items list is empty', () => {
     const out = buildVersions([], ['n'], ['p'], 10);
     expect(out).toEqual({ positive: '', negative: '' });


### PR DESCRIPTION
## Summary
- account for positive modifier count when inserting negative mods after positives
- test depth offsets when positive mods are included

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868fd5735488321aced99c7452a3a3f