### PR TITLE
Fix negative depth with positive mods

### DIFF
--- a/src/lib/promptUtils.js
+++ b/src/lib/promptUtils.js
@@ -111,7 +111,10 @@
     if (itemOrder) items = applyOrder(items, itemOrder);
     const prefixPool = prefixOrder ? applyOrder(prefixes, prefixOrder) : prefixes.slice();
     const dividerPool = dividers.slice();
-    const depthPool = Array.isArray(depths) ? depths.slice() : null;
+    let depthPool = null;
+    if (Array.isArray(depths)) {
+      depthPool = Array.isArray(depths[0]) ? depths.map(d => d.slice()) : depths.slice();
+    }
     const result = [];
     let idx = 0;
     let divIdx = 0;
@@ -119,7 +122,15 @@
       const needDivider = idx > 0 && idx % items.length === 0 && dividerPool.length;
       const prefix = prefixPool.length ? prefixPool[idx % prefixPool.length] : '';
       const item = items[idx % items.length];
-      const depth = depthPool ? depthPool[idx % depthPool.length] : 0;
+      let depth = 0;
+      if (depthPool) {
+        if (Array.isArray(depthPool[0])) {
+          const arr = depthPool[0];
+          depth = arr[idx % arr.length] || 0;
+        } else {
+          depth = depthPool[idx % depthPool.length] || 0;
+        }
+      }
       const term = prefix ? insertAtDepth(item, prefix, depth) : item;
       const pieces = [];
       if (needDivider) pieces.push(dividerPool[divIdx % dividerPool.length]);
@@ -168,17 +179,34 @@
     const dividerPool = dividers.slice();
     let items = baseItems.slice();
     if (itemOrder) items = applyOrder(items, itemOrder);
-    const depthPool = Array.isArray(depths) ? depths.slice() : null;
+    let depthPool = null;
+    if (Array.isArray(depths)) {
+      depthPool = Array.isArray(depths[0]) ? depths.map(d => d.slice()) : depths.slice();
+    }
     const result = [];
     let idx = 0;
     let divIdx = 0;
     while (true) {
       const needDivider = idx > 0 && idx % items.length === 0 && dividerPool.length;
       let term = items[idx % items.length];
-      orders.forEach(mods => {
+      const inserted = [];
+      orders.forEach((mods, sidx) => {
         const mod = mods[idx % mods.length];
-        const depth = depthPool ? depthPool[idx % depthPool.length] : 0;
-        term = mod ? insertAtDepth(term, mod, depth) : term;
+        let depth = 0;
+        if (depthPool) {
+          if (Array.isArray(depthPool[sidx])) {
+            const arr = depthPool[sidx];
+            depth = arr[idx % arr.length] || 0;
+          } else {
+            depth = depthPool[idx % depthPool.length] || 0;
+          }
+        }
+        const offset = inserted.filter(d => d <= depth).length;
+        const adj = depth + offset;
+        if (mod) {
+          term = insertAtDepth(term, mod, adj);
+          inserted.push(adj);
+        }
       });
       const pieces = [];
       if (needDivider) pieces.push(dividerPool[divIdx % dividerPool.length]);
@@ -229,7 +257,10 @@
     let modIdx = 0;
     let items = posTerms.slice();
     if (itemOrder) items = applyOrder(items, itemOrder);
-    const depthPool = Array.isArray(depths) ? depths.slice() : null;
+    let depthPool = null;
+    if (Array.isArray(depths)) {
+      depthPool = Array.isArray(depths[0]) ? depths.map(d => d.slice()) : depths.slice();
+    }
     for (let i = 0; i < items.length; i++) {
       const base = items[i];
       if (dividerSet.has(base)) {
@@ -241,10 +272,24 @@
         continue;
       }
       let term = base;
-      orders.forEach(mods => {
+      const inserted = [];
+      orders.forEach((mods, sidx) => {
         const mod = mods[modIdx % mods.length];
-        const depth = depthPool ? depthPool[modIdx % depthPool.length] : 0;
-        term = mod ? insertAtDepth(term, mod, depth) : term;
+        let depth = 0;
+        if (depthPool) {
+          if (Array.isArray(depthPool[sidx])) {
+            const arr = depthPool[sidx];
+            depth = arr[modIdx % arr.length] || 0;
+          } else {
+            depth = depthPool[modIdx % depthPool.length] || 0;
+          }
+        }
+        const offset = inserted.filter(d => d <= depth).length;
+        const adj = depth + offset;
+        if (mod) {
+          term = insertAtDepth(term, mod, adj);
+          inserted.push(adj);
+        }
       });
       const candidate =
         (result.length ? result.join(delimited ? '' : ', ') + (delimited ? '' : ', ') : '') +
@@ -291,6 +336,16 @@
       baseOrder,
       depths
     );
+    let negDepths = depths;
+    if (includePosForNeg && Array.isArray(depths) && posStackSize > 0) {
+      if (Array.isArray(depths[0])) {
+        negDepths = depths.map(arr =>
+          arr.map(d => (d > 0 ? d + posStackSize : d))
+        );
+      } else {
+        negDepths = depths.map(d => (d > 0 ? d + posStackSize : d));
+      }
+    }
     const negTerms = includePosForNeg
       ? applyNegativeOnPositive(
           posTerms,
@@ -301,7 +356,7 @@
           delimited,
           dividerPool,
           null,
-          depths
+          negDepths
         )
       : applyModifierStack(
           items,

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -92,7 +92,8 @@
       return result;
     }
 
-    const insertDepths = collectDepths('pos', posStackOn ? posStackSize : 1);
+    const rawDepths = collectDepths('pos', posStackOn ? posStackSize : 1);
+    const insertDepths = posStackOn ? rawDepths : rawDepths[0];
     const baseOrder = utils.parseOrderInput(document.getElementById('base-order-input')?.value || '');
     function collectOrders(prefix, count) {
       const result = [];

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -92,8 +92,10 @@
       return result;
     }
 
-    const rawDepths = collectDepths('pos', posStackOn ? posStackSize : 1);
-    const insertDepths = posStackOn ? rawDepths : rawDepths[0];
+    const rawPosDepths = collectDepths('pos', posStackOn ? posStackSize : 1);
+    const posDepths = posStackOn ? rawPosDepths : rawPosDepths[0];
+    const rawNegDepths = collectDepths('neg', negStackOn ? negStackSize : 1);
+    const negDepths = negStackOn ? rawNegDepths : rawNegDepths[0];
     const baseOrder = utils.parseOrderInput(document.getElementById('base-order-input')?.value || '');
     function collectOrders(prefix, count) {
       const result = [];
@@ -124,7 +126,7 @@
       dividerMods,
       shuffleDividers,
       dividerOrder,
-      insertDepths,
+      insertDepths: { pos: posDepths, neg: negDepths },
       baseOrder,
       posOrder,
       negOrder

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -139,7 +139,7 @@ describe('Prompt building', () => {
   });
 
   test('buildVersions offsets depth for negatives when positives included', () => {
-    const out = buildVersions(['cat'], ['bad'], ['good'], 20, true, [], true, 1, 1, [1]);
+    const out = buildVersions(['cat'], ['bad'], ['good'], 20, true, [], true, 1, 1, { pos: [1], neg: [1] });
     expect(out).toEqual({ positive: 'cat good', negative: 'cat good bad' });
   });
 
@@ -154,7 +154,7 @@ describe('Prompt building', () => {
       true,
       2,
       1,
-      [[1], [2]]
+      { pos: [[1], [2]], neg: [1] }
     );
     expect(out).toEqual({ positive: 'a x b y c', negative: 'a n b c' });
   });
@@ -170,7 +170,7 @@ describe('Prompt building', () => {
       true,
       2,
       1,
-      [1]
+      { pos: [1], neg: [1] }
     );
     expect(out).toEqual({ positive: 'foo good great bar baz', negative: 'foo good great bad bar baz' });
   });
@@ -186,7 +186,7 @@ describe('Prompt building', () => {
       true,
       2,
       1,
-      [[0], [2]]
+      { pos: [[0], [2]], neg: [0] }
     );
     expect(out).toEqual({ positive: 'pre foo bar post, pre foo bar post', negative: 'n foo bar, n foo bar' });
   });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -138,6 +138,59 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
   });
 
+  test('buildVersions offsets depth for negatives when positives included', () => {
+    const out = buildVersions(['cat'], ['bad'], ['good'], 20, true, [], true, 1, 1, [1]);
+    expect(out).toEqual({ positive: 'cat good', negative: 'cat good bad' });
+  });
+
+  test('buildVersions respects depth arrays per stack', () => {
+    const out = buildVersions(
+      ['a b c'],
+      ['n'],
+      [['x'], ['y']],
+      15,
+      false,
+      [],
+      true,
+      2,
+      1,
+      [[1], [2]]
+    );
+    expect(out).toEqual({ positive: 'a x b y c', negative: 'a n b c' });
+  });
+
+  test('negative depth offset accounts for stacked positives', () => {
+    const out = buildVersions(
+      ['foo bar baz'],
+      ['bad'],
+      [['good'], ['great']],
+      40,
+      true,
+      [],
+      true,
+      2,
+      1,
+      [1]
+    );
+    expect(out).toEqual({ positive: 'foo good great bar baz', negative: 'foo good great bad bar baz' });
+  });
+
+  test('stacked modifiers handle prepend and append depths', () => {
+    const out = buildVersions(
+      ['foo bar'],
+      ['n'],
+      [['pre'], ['post']],
+      50,
+      false,
+      [],
+      true,
+      2,
+      1,
+      [[0], [2]]
+    );
+    expect(out).toEqual({ positive: 'pre foo bar post, pre foo bar post', negative: 'n foo bar, n foo bar' });
+  });
+
   test('buildVersions returns empty strings when items list is empty', () => {
     const out = buildVersions([], ['n'], ['p'], 10);
     expect(out).toEqual({ positive: '', negative: '' });
@@ -248,8 +301,8 @@ describe('Prompt building', () => {
       [[0, 1], [1, 0]],
       [[1, 0], [0, 1]]
     );
-    expect(out.positive).toBe('p2 p1 x, p1 p2 x');
-    expect(out.negative).toBe('n1 n2 x, n2 n1 x');
+    expect(out.positive).toBe('p1 p2 x, p2 p1 x');
+    expect(out.negative).toBe('n2 n1 x, n1 n2 x');
   });
 
   test('buildVersions accepts different lists per stack', () => {
@@ -264,8 +317,8 @@ describe('Prompt building', () => {
       2,
       2
     );
-    expect(out.positive).toBe('p2 p1 x, p2 p1 x');
-    expect(out.negative).toBe('n2 n1 x, n2 n1 x');
+    expect(out.positive).toBe('p1 p2 x, p1 p2 x');
+    expect(out.negative).toBe('n1 n2 x, n1 n2 x');
   });
 
   test('stacking works with natural dividers', () => {


### PR DESCRIPTION
## Summary
- account for positive modifier count when inserting negative mods after positives
- support depth arrays per stack
- fix UI depth collection for simple mode
- test advanced depth alignment and stacking
- fix stacked depth alignment with offset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868fd5735488321aced99c7452a3a3f