### PR TITLE
Move preset data to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ src/
 ├── style.css           # Dark theme styling
 ├── assets/
 │   └── logo.png        # Diskrot logo
-└── default_list.js        # Modifier presets
+└── default_list.json        # Modifier presets
 ```
 
 ### Key Files
@@ -94,26 +94,26 @@ src/
 - **index.html**: Contains the user interface with dynamically populated dropdown menus
 - **script.js**: Implements the prompt generation algorithm with comprehensive comments
 - **style.css**: Provides responsive dark theme styling with gradient backgrounds
-- **default_list.js**: Contains curated modifier lists in a structured format
+- **default_list.json**: Contains curated modifier lists in a structured format
 
 ## Customization
 
 ### Adding New Preset Lists
 
-Edit the preset file `src/default_list.js`:
+Edit the preset file `src/default_list.json`:
 
-```javascript
-const DEFAULT_LIST = {
-  presets: [
+```json
+{
+  "presets": [
     {
-      id: 'your-list-id',
-      title: 'Your List Title',
-      type: 'negative',
-      items: ['item1', 'item2', 'item3']
+      "id": "your-list-id",
+      "title": "Your List Title",
+      "type": "negative",
+      "items": ["item1", "item2", "item3"]
     }
     // ... more presets
   ]
-};
+}
 ```
 
 Each preset includes a `type` of `negative`, `positive` or `length`. Length presets use a single numeric value in `items`.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -11,7 +11,7 @@ src/
   style.css         # styling
   assets/           # images and fonts
   lib/              # pure functions only
-  default_list.js   # preset data
+  default_list.json   # preset data
   stateManager.js   # state container
   listManager.js    # preset list helpers
   storageManager.js # persistence helpers

--- a/src/default_list.json
+++ b/src/default_list.json
@@ -1,4 +1,4 @@
-const DEFAULT_LIST = {
+{
   "presets": [
     {
       "id": "empty",
@@ -705,9 +705,9 @@ const DEFAULT_LIST = {
         "Namely, ",
         "Rephrased, ",
         "To say it another way, ",
-    "Let me put it this way. "
-  ],
-  "type": "divider"
+        "Let me put it this way. "
+      ],
+      "type": "divider"
     }
   ]
-};
+}

--- a/src/index.html
+++ b/src/index.html
@@ -290,8 +290,6 @@
   </script>
 
   <!-- External script loading order is important -->
-  <!-- Load list data files first -->
-  <script src="default_list.js"></script>
   <!-- Load submodules before main script -->
   <script src="lib/promptUtils.js"></script>
   <script src="listManager.js"></script>

--- a/src/listManager.js
+++ b/src/listManager.js
@@ -8,26 +8,25 @@
   let LYRICS_PRESETS = {};
   let ORDER_PRESETS = {};
 
-  let LISTS;
-  if (typeof DEFAULT_LIST !== 'undefined' && Array.isArray(DEFAULT_LIST.presets)) {
-    LISTS = JSON.parse(JSON.stringify(DEFAULT_LIST));
-  } else if (
-    typeof NEGATIVE_LISTS !== 'undefined' ||
-    typeof POSITIVE_LISTS !== 'undefined' ||
-    typeof LENGTH_LISTS !== 'undefined'
-  ) {
-    LISTS = { presets: [] };
-    if (typeof NEGATIVE_LISTS !== 'undefined') {
-      NEGATIVE_LISTS.presets.forEach(p => LISTS.presets.push({ ...p, type: 'negative' }));
+  let LISTS = { presets: [] };
+
+  async function loadPresets(path = 'default_list.json') {
+    try {
+      let data;
+      if (typeof module !== 'undefined' && module.exports) {
+        const fs = require('fs');
+        const p = require('path');
+        const loc = p.isAbsolute(path) ? path : p.join(__dirname, path);
+        data = JSON.parse(fs.readFileSync(loc, 'utf8'));
+      } else {
+        const res = await fetch(path);
+        data = await res.json();
+      }
+      LISTS = data;
+      loadLists();
+    } catch (err) {
+      LISTS = { presets: [] };
     }
-    if (typeof POSITIVE_LISTS !== 'undefined') {
-      POSITIVE_LISTS.presets.forEach(p => LISTS.presets.push({ ...p, type: 'positive' }));
-    }
-    if (typeof LENGTH_LISTS !== 'undefined') {
-      LENGTH_LISTS.presets.forEach(p => LISTS.presets.push({ ...p, type: 'length' }));
-    }
-  } else {
-    LISTS = { presets: [] };
   }
 
   function populateSelect(selectEl, presets) {
@@ -212,6 +211,7 @@
     get BASE_PRESETS() { return BASE_PRESETS; },
     get LYRICS_PRESETS() { return LYRICS_PRESETS; },
     get ORDER_PRESETS() { return ORDER_PRESETS; },
+    loadPresets,
     loadLists,
     exportLists,
     importLists,

--- a/src/script.js
+++ b/src/script.js
@@ -5,11 +5,11 @@
   const state = global.stateManager || (typeof require !== 'undefined' && require('./stateManager'));
 
   if (typeof document !== 'undefined' && !(typeof window !== 'undefined' && window.__TEST__)) {
-    const init = ui.initializeUI;
+    const start = () => lists.loadPresets().then(ui.initializeUI);
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', init);
+      document.addEventListener('DOMContentLoaded', start);
     } else {
-      init();
+      start();
     }
   }
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,5 +5,6 @@ This directory contains Jest test suites verifying functionality of the Prompt E
 - **Targeted Coverage**: For every new feature or bug fix, add a focused test that exercises the specific behavior. Reproduce previously observed issues so the bug cannot recur.
 - **Reusable Helpers**: Implement small utilities that load presets, generate prompts and save lists so that tests can chain these actions together. Helpers should keep DOM setup short and make it easy to compose common workflows.
 - **Randomized Sequential Tests**: In addition to deterministic unit tests, create tests that simulate a full user session. Randomly perform a sequence of actions—load, generate, modify, save—and assert that no errors are thrown and the generated output remains valid. Run these sequences multiple times to explore edge cases.
+- **Browser vs Node Loading**: When modules fetch external resources, test both Node and browser code paths. Simulate network failures and ensure graceful fallbacks so opening `src/index.html` without a server continues to work.
 
 All tests must run with `npm test` as described in the repository root instructions.

--- a/tests/listManager.test.js
+++ b/tests/listManager.test.js
@@ -15,3 +15,26 @@ test('loadPresets loads default JSON', async () => {
   global.__TEST__ = true;
   if (typeof window !== 'undefined') window.__TEST__ = true;
 });
+
+test('loadPresets falls back when fetch fails', async () => {
+  const json = require('fs').readFileSync(
+    path.join(__dirname, '..', 'src', 'default_list.json'),
+    'utf8'
+  );
+  const oldFetch = global.fetch;
+  const oldXHR = global.XMLHttpRequest;
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')));
+  function XHR() {
+    this.open = jest.fn();
+    this.send = jest.fn(() => {
+      this.status = 200;
+      this.responseText = json;
+    });
+  }
+  global.XMLHttpRequest = XHR;
+  await lists.loadPresets(path.join(__dirname, '..', 'src', 'default_list.json'));
+  const data = JSON.parse(lists.exportLists());
+  expect(data.presets.length).toBeGreaterThan(0);
+  global.fetch = oldFetch;
+  global.XMLHttpRequest = oldXHR;
+});

--- a/tests/listManager.test.js
+++ b/tests/listManager.test.js
@@ -1,0 +1,17 @@
+/** @jest-environment jsdom */
+
+const path = require('path');
+const lists = require('../src/listManager');
+
+global.__TEST__ = true;
+if (typeof window !== 'undefined') window.__TEST__ = true;
+
+test('loadPresets loads default JSON', async () => {
+  global.__TEST__ = false;
+  if (typeof window !== 'undefined') window.__TEST__ = false;
+  await lists.loadPresets(path.join(__dirname, '..', 'src', 'default_list.json'));
+  const data = JSON.parse(lists.exportLists());
+  expect(data.presets.length).toBeGreaterThan(0);
+  global.__TEST__ = true;
+  if (typeof window !== 'undefined') window.__TEST__ = true;
+});


### PR DESCRIPTION
## Summary
- convert `default_list.js` to JSON format
- add `loadPresets` loader for presets
- update script initialization
- update docs and HTML to reference the JSON
- cover preset loading with new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68690abc4ba88321a8da65518eed4bf6