### PR TITLE
Switch default list to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ src/
 ├── style.css           # Dark theme styling
 ├── assets/
 │   └── logo.png        # Diskrot logo
-└── default_list.js        # Modifier presets
+└── default_list.json        # Modifier presets
 ```
 
 ### Key Files
@@ -94,26 +94,26 @@ src/
 - **index.html**: Contains the user interface with dynamically populated dropdown menus
 - **script.js**: Implements the prompt generation algorithm with comprehensive comments
 - **style.css**: Provides responsive dark theme styling with gradient backgrounds
-- **default_list.js**: Contains curated modifier lists in a structured format
+- **default_list.json**: Contains curated modifier lists in a structured format
 
 ## Customization
 
 ### Adding New Preset Lists
 
-Edit the preset file `src/default_list.js`:
+Edit the preset file `src/default_list.json`:
 
-```javascript
-const DEFAULT_LIST = {
-  presets: [
+```json
+{
+  "presets": [
     {
-      id: 'your-list-id',
-      title: 'Your List Title',
-      type: 'negative',
-      items: ['item1', 'item2', 'item3']
+      "id": "your-list-id",
+      "title": "Your List Title",
+      "type": "negative",
+      "items": ["item1", "item2", "item3"]
     }
     // ... more presets
   ]
-};
+}
 ```
 
 Each preset includes a `type` of `negative`, `positive` or `length`. Length presets use a single numeric value in `items`.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -11,7 +11,7 @@ src/
   style.css         # styling
   assets/           # images and fonts
   lib/              # pure functions only
-  default_list.js   # preset data
+  default_list.json   # preset data
   stateManager.js   # state container
   listManager.js    # preset list helpers
   storageManager.js # persistence helpers

--- a/src/default_list.json
+++ b/src/default_list.json
@@ -1,4 +1,4 @@
-const DEFAULT_LIST = {
+{
   "presets": [
     {
       "id": "empty",
@@ -710,4 +710,4 @@ const DEFAULT_LIST = {
   "type": "divider"
     }
   ]
-};
+}

--- a/src/index.html
+++ b/src/index.html
@@ -291,7 +291,7 @@
 
   <!-- External script loading order is important -->
   <!-- Load list data files first -->
-  <script src="default_list.js"></script>
+  <script src="loadDefaultList.js"></script>
   <!-- Load submodules before main script -->
   <script src="lib/promptUtils.js"></script>
   <script src="listManager.js"></script>

--- a/src/loadDefaultList.js
+++ b/src/loadDefaultList.js
@@ -1,0 +1,10 @@
+(function (global) {
+  var request = new XMLHttpRequest();
+  request.open('GET', 'default_list.json', false);
+  request.send(null);
+  if (request.status >= 200 && request.status < 300) {
+    global.DEFAULT_LIST = JSON.parse(request.responseText);
+  } else {
+    global.DEFAULT_LIST = { presets: [] };
+  }
+})(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
## Summary
- convert `default_list.js` to `default_list.json`
- load JSON synchronously via `loadDefaultList.js`
- update index and docs for the new file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869114fe6d88321b52cc4132fac5448