### PR TITLE
Fix depth persistence on save

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -43,6 +43,23 @@
     });
   }
 
+  function populateDepthSelect(selectEl, presets) {
+    if (!selectEl) return;
+    selectEl.innerHTML = '';
+    const opts = [
+      { id: 'prepend', title: 'Prepend' },
+      { id: 'append', title: 'Append' },
+      { id: 'random', title: 'Random Depth' }
+    ];
+    presets.forEach(p => opts.push({ id: p.id, title: p.title }));
+    opts.forEach(o => {
+      const opt = document.createElement('option');
+      opt.value = o.id;
+      opt.textContent = o.title;
+      selectEl.appendChild(opt);
+    });
+  }
+
   function loadLists() {
     NEG_PRESETS = {};
     POS_PRESETS = {};
@@ -96,9 +113,9 @@
     const lyricsSelect = document.getElementById('lyrics-select');
     if (lyricsSelect) populateSelect(lyricsSelect, lyrics);
     const posDepthSelect = document.getElementById('pos-depth-select');
-    if (posDepthSelect) populateSelect(posDepthSelect, order);
+    if (posDepthSelect) populateDepthSelect(posDepthSelect, order);
     const negDepthSelect = document.getElementById('neg-depth-select');
-    if (negDepthSelect) populateSelect(negDepthSelect, order);
+    if (negDepthSelect) populateDepthSelect(negDepthSelect, order);
   }
 
   function exportLists() {

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -43,11 +43,17 @@
     'lyrics-remove-parens',
     'lyrics-remove-brackets',
     'pos-depth-select',
+    'pos-depth-input',
     'neg-depth-select',
+    'neg-depth-input',
     'base-order-select',
+    'base-order-input',
     'pos-order-select',
+    'pos-order-input',
     'neg-order-select',
-    'divider-order-select'
+    'neg-order-input',
+    'divider-order-select',
+    'divider-order-input'
   ];
 
   function loadFromDOM() {

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -94,4 +94,16 @@ describe('State manager integration', () => {
     const again = state.exportState();
     expect(again).toBe(json);
   });
+
+  test('depth values persist through export and import', () => {
+    document.getElementById('pos-depth-input').value = '1,2';
+    document.getElementById('neg-depth-input').value = '3';
+    state.loadFromDOM();
+    const json = state.exportState();
+    document.getElementById('pos-depth-input').value = '';
+    document.getElementById('neg-depth-input').value = '';
+    state.importState(JSON.parse(json));
+    expect(document.getElementById('pos-depth-input').value).toBe('1,2');
+    expect(document.getElementById('neg-depth-input').value).toBe('3');
+  });
 });

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -36,4 +36,28 @@ describe('Storage manager', () => {
     storage.importData(json);
     expect(document.getElementById('pos-depth-input').value).toBe('4');
   });
+
+  test('importData keeps builtin depth options', () => {
+    lists.importLists({
+      presets: [
+        { id: 'ord', title: 'ord', type: 'order', items: ['0'] },
+        { id: 'b', title: 'b', type: 'base', items: ['x'] }
+      ]
+    });
+    const json = storage.exportData();
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+      <select id="pos-depth-select"></select>
+      <textarea id="pos-depth-input"></textarea>
+    `;
+    lists.importLists({ presets: [] });
+    storage.importData(json);
+    const opts = Array.from(
+      document.querySelectorAll('#pos-depth-select option')
+    ).map(o => o.value);
+    expect(opts).toEqual(
+      expect.arrayContaining(['prepend', 'append', 'random', 'ord'])
+    );
+  });
 });

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -8,6 +8,8 @@ function setupDOM() {
   document.body.innerHTML = `
     <select id="base-select"></select>
     <textarea id="base-input"></textarea>
+    <select id="pos-depth-select"></select>
+    <textarea id="pos-depth-input"></textarea>
   `;
 }
 
@@ -25,5 +27,13 @@ describe('Storage manager', () => {
     storage.importData(json);
     const after = storage.exportData();
     expect(after).toBe(json);
+  });
+
+  test('depth input preserved through exportData/importData', () => {
+    document.getElementById('pos-depth-input').value = '4';
+    const json = storage.exportData();
+    document.getElementById('pos-depth-input').value = '';
+    storage.importData(json);
+    expect(document.getElementById('pos-depth-input').value).toBe('4');
   });
 });


### PR DESCRIPTION
## Summary
- persist depth and order inputs in state manager
- cover depth persistence in stateManager and storageManager tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686916377b748321a323ca764c36234d