### PR TITLE
Add persistent local storage

### DIFF
--- a/src/default_data.js
+++ b/src/default_data.js
@@ -1,0 +1,4 @@
+const DEFAULT_DATA = {
+  lists: DEFAULT_LIST,
+  state: {}
+};

--- a/src/index.html
+++ b/src/index.html
@@ -292,6 +292,7 @@
   <!-- External script loading order is important -->
   <!-- Load list data files first -->
   <script src="default_list.js"></script>
+  <script src="default_data.js"></script>
   <!-- Load submodules before main script -->
   <script src="lib/promptUtils.js"></script>
   <script src="listManager.js"></script>

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -2,6 +2,27 @@
   const lists = global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const state = global.stateManager || (typeof require !== 'undefined' && require('./stateManager'));
 
+  const KEY = 'promptEnhancerData';
+
+  function saveLocal(data) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(KEY, JSON.stringify(data));
+    } catch (err) {
+      /* ignore */
+    }
+  }
+
+  function loadLocal() {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const json = localStorage.getItem(KEY);
+      return json ? JSON.parse(json) : null;
+    } catch (err) {
+      return null;
+    }
+  }
+
   function exportData() {
     const listData = JSON.parse(lists.exportLists());
     state.loadFromDOM();
@@ -22,9 +43,26 @@
     if (typeof data !== 'object') return;
     if (data.lists) lists.importLists(data.lists);
     if (data.state) state.importState(data.state);
+    saveLocal(data);
   }
 
-  const api = { exportData, importData };
+  function persist() {
+    const json = exportData();
+    saveLocal(JSON.parse(json));
+  }
+
+  function loadPersisted() {
+    const stored = loadLocal();
+    if (stored) {
+      importData(stored);
+      return;
+    }
+    if (typeof DEFAULT_DATA !== 'undefined') {
+      importData(DEFAULT_DATA);
+    }
+  }
+
+  const api = { exportData, importData, persist, loadPersisted };
 
   if (typeof module !== 'undefined') {
     module.exports = api;

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -821,7 +821,7 @@
   }
 
   function initializeUI() {
-    lists.loadLists();
+    storage.loadPersisted();
     applyPreset(document.getElementById('neg-select'), document.getElementById('neg-input'), 'negative');
     applyPreset(document.getElementById('pos-select'), document.getElementById('pos-input'), 'positive');
     applyPreset(document.getElementById('length-select'), document.getElementById('length-input'), 'length');
@@ -899,6 +899,9 @@
     if (divSave) divSave.addEventListener('click', () => lists.saveList('divider'));
     const lyricsSave = document.getElementById('lyrics-save');
     if (lyricsSave) lyricsSave.addEventListener('click', () => lists.saveList('lyrics'));
+    if (typeof window !== 'undefined') {
+      window.addEventListener('beforeunload', () => storage.persist());
+    }
   }
 
   const api = {

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -60,4 +60,34 @@ describe('Storage manager', () => {
       expect.arrayContaining(['prepend', 'append', 'random', 'ord'])
     );
   });
+
+  test('loadPersisted prefers localStorage data', () => {
+    const saved = {
+      lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['y'] }] },
+      state: { 'base-input': 'y', 'base-select': 'b' }
+    };
+    localStorage.setItem('promptEnhancerData', JSON.stringify(saved));
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+    `;
+    storage.loadPersisted();
+    const txt = document.getElementById('base-input').value;
+    expect(txt).toBe('y');
+  });
+
+  test('loadPersisted falls back to DEFAULT_DATA', () => {
+    localStorage.removeItem('promptEnhancerData');
+    global.DEFAULT_DATA = {
+      lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['z'] }] },
+      state: { 'base-input': 'z', 'base-select': 'b' }
+    };
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+    `;
+    storage.loadPersisted();
+    const txt = document.getElementById('base-input').value;
+    expect(txt).toBe('z');
+  });
 });


### PR DESCRIPTION
## Summary
- support automatic save/load of state and lists with localStorage
- load saved data on startup or fall back to default
- expose persistence helpers in `storageManager`
- persist data before closing the page
- test localStorage behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691ab0fbb08321bf73407c7664febe