### PR TITLE
Remove loadListsFromFile and downloadLists

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -156,31 +156,6 @@
     loadLists();
   }
 
-  function loadListsFromFile(file, additive = false) {
-    const reader = new FileReader();
-    reader.onload = () => {
-      try {
-        const data = JSON.parse(reader.result);
-        importLists(data, additive);
-      } catch (err) {
-        alert('Invalid lists file');
-      }
-    };
-    reader.readAsText(file);
-  }
-
-  function downloadLists() {
-    const blob = new Blob([exportLists()], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'lists.json';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  }
-
   function saveList(type) {
     const map = {
       base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
@@ -232,9 +207,7 @@
     loadLists,
     exportLists,
     importLists,
-    saveList,
-    loadListsFromFile,
-    downloadLists
+    saveList
   };
 
   if (typeof module !== 'undefined') {


### PR DESCRIPTION
## Summary
- delete unused `loadListsFromFile` and `downloadLists` utilities
- drop exports for the removed functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869231f31488321b57480eab8e2f9e3