### PR TITLE
Add controls for stacked inputs

### DIFF
--- a/src/listManager.js
+++ b/src/listManager.js
@@ -156,7 +156,7 @@
     loadLists();
   }
 
-  function saveList(type) {
+  function saveList(type, index = 1) {
     const map = {
       base: { select: 'base-select', input: 'base-input', store: BASE_PRESETS },
       negative: { select: 'neg-select', input: 'neg-input', store: NEG_PRESETS },
@@ -168,8 +168,10 @@
     };
     const cfg = map[type];
     if (!cfg) return;
-    const sel = document.getElementById(cfg.select);
-    const inp = document.getElementById(cfg.input);
+    const selId = index === 1 ? cfg.select : `${cfg.select}-${index}`;
+    const inpId = index === 1 ? cfg.input : `${cfg.input}-${index}`;
+    const sel = document.getElementById(selId);
+    const inp = document.getElementById(inpId);
     if (!sel || !inp) return;
     const name = prompt('Enter list name', sel.value);
     if (!name) return;
@@ -188,7 +190,13 @@
       const opt = document.createElement('option');
       opt.value = name;
       opt.textContent = name;
-      sel.appendChild(opt);
+      document
+        .querySelectorAll(`select[id^="${cfg.select}"]`)
+        .forEach(s => {
+          if (!s.querySelector(`option[value="${name}"]`)) {
+            s.appendChild(opt.cloneNode(true));
+          }
+        });
     } else {
       preset.items = items;
     }

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -530,6 +530,47 @@
       block.className = 'stack-block';
       block.id = `${prefix}-stack-${idx}`;
 
+      if (idx > 1) {
+        const labelRow = document.createElement('div');
+        labelRow.className = 'label-row';
+        const lbl = document.createElement('label');
+        lbl.textContent = `Stack ${idx}`;
+        labelRow.appendChild(lbl);
+        const btnCol = document.createElement('div');
+        btnCol.className = 'button-col';
+        const save = document.createElement('button');
+        save.type = 'button';
+        save.id = `${prefix}-save-${idx}`;
+        save.className = 'save-button icon-button';
+        save.title = 'Save';
+        save.innerHTML = '&#128190;';
+        save.addEventListener('click', () => lists.saveList(type, idx));
+        btnCol.appendChild(save);
+        const copy = document.createElement('button');
+        copy.type = 'button';
+        copy.className = 'copy-button icon-button';
+        copy.dataset.target = `${prefix}-input-${idx}`;
+        copy.title = 'Copy';
+        copy.innerHTML = '&#128203;';
+        btnCol.appendChild(copy);
+        const hideCb = document.createElement('input');
+        hideCb.type = 'checkbox';
+        hideCb.id = `${prefix}-hide-${idx}`;
+        hideCb.dataset.targets = `${prefix}-input-${idx},${prefix}-order-input-${idx}`;
+        hideCb.hidden = true;
+        btnCol.appendChild(hideCb);
+        const hideBtn = document.createElement('button');
+        hideBtn.type = 'button';
+        hideBtn.className = 'toggle-button icon-button hide-button';
+        hideBtn.dataset.target = hideCb.id;
+        hideBtn.dataset.on = '☰';
+        hideBtn.dataset.off = '✖';
+        hideBtn.textContent = '☰';
+        btnCol.appendChild(hideBtn);
+        labelRow.appendChild(btnCol);
+        block.appendChild(labelRow);
+      }
+
       const sel = document.createElement('select');
       sel.id = `${prefix}-select-${idx}`;
       const baseSel = document.getElementById(`${prefix}-select`);
@@ -605,6 +646,8 @@
       const block = document.getElementById(`${prefix}-stack-${i}`);
       if (block) block.remove();
     }
+    setupCopyButtons();
+    setupHideToggles();
     const adv = document.getElementById('advanced-mode');
     if (adv && !adv.checked) adv.dispatchEvent(new Event('change'));
   }
@@ -845,6 +888,7 @@
     setupDataButtons,
     setupOrderControl,
     setupAdvancedToggle,
+    updateStackBlocks,
     rerollRandomOrders,
     setupRerollButton,
     initializeUI

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -32,7 +32,8 @@ const {
   setupOrderControl,
   setupRerollButton,
   rerollRandomOrders,
-  setupAdvancedToggle
+  setupAdvancedToggle,
+  updateStackBlocks
 } = ui;
 
 describe('Utility functions', () => {
@@ -960,5 +961,19 @@ describe('List persistence', () => {
     const data = JSON.parse(exportLists());
     const lists = data.presets.filter(p => p.id === 'a' && p.type === 'positive');
     expect(lists.length).toBe(2);
+  });
+
+  test('updateStackBlocks adds buttons for extra stacks', () => {
+    document.body.innerHTML = `
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1"></div>
+      </div>`;
+    updateStackBlocks('pos', 2);
+    const block = document.getElementById('pos-stack-2');
+    expect(block.querySelector('.copy-button')).not.toBeNull();
+    expect(block.querySelector('.save-button')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- allow saving lists from specific stack indexes
- render save/copy/hide controls for dynamically added stacks
- export `updateStackBlocks` for testing
- test stack block control creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b94509af4832185d0689b69030529