### PR TITLE
Fix all-hide toggle and add regression test

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -363,7 +363,27 @@
       cb.addEventListener('change', update);
       update();
     });
+    const allHide = document.getElementById('all-hide');
+    if (allHide && allHide.checked) applyAllHideState();
     return hideCheckboxes;
+  }
+
+  function applyAllHideState() {
+    const allHide = document.getElementById('all-hide');
+    if (!allHide) return;
+    const hideCheckboxes = Array.from(
+      document.querySelectorAll('input[type="checkbox"][data-targets]')
+    );
+    hideCheckboxes.forEach(cb => {
+      cb.checked = allHide.checked;
+      const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
+      if (btn) updateButtonState(btn, cb);
+      cb.dispatchEvent(new Event('change'));
+    });
+    const allHideBtn = document.querySelector(
+      '.toggle-button[data-target="all-hide"]'
+    );
+    if (allHideBtn) updateButtonState(allHideBtn, allHide);
   }
 
   function setupCopyButtons() {
@@ -838,20 +858,12 @@
     setupToggleButtons();
     setupStackControls();
     setupShuffleAll();
-    const hideCheckboxes = setupHideToggles();
+    setupHideToggles();
 
     const allHide = document.getElementById('all-hide');
     if (allHide) {
-      allHide.addEventListener('change', () => {
-        hideCheckboxes.forEach(cb => {
-          cb.checked = allHide.checked;
-          const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
-          if (btn) updateButtonState(btn, cb);
-          cb.dispatchEvent(new Event('change'));
-        });
-        const allHideBtn = document.querySelector('.toggle-button[data-target="all-hide"]');
-        if (allHideBtn) updateButtonState(allHideBtn, allHide);
-      });
+      allHide.addEventListener('change', applyAllHideState);
+      if (allHide.checked) applyAllHideState();
     }
 
     setupCopyButtons();
@@ -885,6 +897,7 @@
     setupShuffleAll,
     setupStackControls,
     setupHideToggles,
+    applyAllHideState,
     setupCopyButtons,
     setupDataButtons,
     setupOrderControl,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -28,6 +28,7 @@ const {
   setupShuffleAll,
   setupStackControls,
   setupHideToggles,
+  applyAllHideState,
   applyPreset,
   setupOrderControl,
   setupRerollButton,
@@ -975,5 +976,36 @@ describe('List persistence', () => {
     const block = document.getElementById('pos-stack-2');
     expect(block.querySelector('.copy-button')).not.toBeNull();
     expect(block.querySelector('.save-button')).not.toBeNull();
+  });
+
+  test('all-hide affects newly created stack blocks', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-hide">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        </div>
+      </div>`;
+    setupStackControls();
+    setupHideToggles();
+    document.getElementById('all-hide').addEventListener('change', applyAllHideState);
+    const allHide = document.getElementById('all-hide');
+    allHide.checked = true;
+    allHide.dispatchEvent(new Event('change'));
+    const posStack = document.getElementById('pos-stack');
+    posStack.checked = true;
+    posStack.dispatchEvent(new Event('change'));
+    const posInput2 = document.getElementById('pos-input-2');
+    expect(posInput2.style.display).toBe('none');
+    allHide.checked = false;
+    allHide.dispatchEvent(new Event('change'));
+    expect(posInput2.style.display).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- ensure newly created stack blocks respect the all-hide quick action
- expose `applyAllHideState` and update hide logic
- test that all-hide also hides additional stacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d00ce36f08321b9aadd47567a03ee