### PR TITLE
Fix stack hide button

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -669,6 +669,7 @@
     }
     setupCopyButtons();
     setupHideToggles();
+    setupToggleButtons();
     const adv = document.getElementById('advanced-mode');
     if (adv && !adv.checked) adv.dispatchEvent(new Event('change'));
   }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1008,4 +1008,31 @@ describe('List persistence', () => {
     allHide.dispatchEvent(new Event('change'));
     expect(posInput2.style.display).toBe('');
   });
+
+  test('hide button works for new stack blocks', () => {
+    document.body.innerHTML = `
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div class="button-col">
+            <input type="checkbox" id="pos-hide" data-targets="pos-input,pos-order-input" hidden>
+            <button class="toggle-button hide-button" data-target="pos-hide"></button>
+          </div>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        </div>
+      </div>`;
+    setupHideToggles();
+    updateStackBlocks('pos', 2);
+    const btn = document.querySelector('#pos-stack-2 .hide-button');
+    const input = document.getElementById('pos-input-2');
+    expect(btn).not.toBeNull();
+    expect(input).not.toBeNull();
+    btn.click();
+    expect(input.style.display).toBe('none');
+    btn.click();
+    expect(input.style.display).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure toggle buttons are initialized when stack blocks are updated
- test that hamburger menu works for new stack blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d75f9bda88321bb43d444f9483c8a