### PR TITLE
Fix section all-hide for stack

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -426,7 +426,7 @@
       hide.addEventListener('change', () => reflectSectionHide(prefix));
       i++;
     }
-    reflectSectionHide(prefix);
+    update();
   }
 
   function setupSectionOrder(prefix) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -36,7 +36,8 @@ const {
   rerollRandomOrders,
   setupAdvancedToggle,
   updateStackBlocks,
-  setupSectionOrder
+  setupSectionOrder,
+  setupSectionHide
 } = ui;
 
 describe('Utility functions', () => {
@@ -1083,6 +1084,42 @@ describe('List persistence', () => {
     allHide.checked = false;
     allHide.dispatchEvent(new Event('change'));
     expect(posInput2.style.display).toBe('');
+  });
+
+  test('section all-hide applies to new stack blocks', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="pos-all-hide">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div class="label-row">
+            <label>Stack 1</label>
+            <div class="button-col">
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
+            </div>
+          </div>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        </div>
+      </div>`;
+    setupToggleButtons();
+    setupStackControls();
+    setupHideToggles();
+    setupSectionHide('pos');
+    const secHide = document.getElementById('pos-all-hide');
+    secHide.checked = true;
+    secHide.dispatchEvent(new Event('change'));
+    const stackCb = document.getElementById('pos-stack');
+    stackCb.checked = true;
+    stackCb.dispatchEvent(new Event('change'));
+    const posInput2 = document.getElementById('pos-input-2');
+    expect(posInput2.style.display).toBe('none');
   });
 
   test('hide button works for dynamically added stack blocks', () => {


### PR DESCRIPTION
## Summary
- ensure section hide state updates newly added stack blocks
- add regression test for section all-hide when creating stacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f983363048321a695ec82c0fa6c74