### PR TITLE
Fix section all-hide and sync global hide state

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -533,11 +533,9 @@
         document.querySelectorAll(`[id^="${id}"]`).forEach(el => setDisplay(el, adv));
       });
       document.querySelectorAll('[id$="-advanced"]').forEach(sec => {
-        if (!sec.dataset.userSet) {
-          sec.checked = adv;
-          const btn = document.querySelector(`.toggle-button[data-target="${sec.id}"]`);
-          if (btn) updateButtonState(btn, sec);
-        }
+        sec.checked = adv;
+        const btn = document.querySelector(`.toggle-button[data-target="${sec.id}"]`);
+        if (btn) updateButtonState(btn, sec);
         sec.dispatchEvent(new Event('change'));
       });
       // Dice buttons remain visible in both modes

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -347,6 +347,8 @@
     );
     const all = cbs.every(cb => cb.checked);
     const any = cbs.some(cb => cb.checked);
+    const globalCb = document.getElementById('all-hide');
+    if (globalCb) globalCb.checked = all;
     const btn = document.querySelector('.toggle-button[data-target="all-hide"]');
     if (btn) {
       btn.classList.remove('active', 'indeterminate');
@@ -426,7 +428,7 @@
       hide.addEventListener('change', () => reflectSectionHide(prefix));
       i++;
     }
-    reflectSectionHide(prefix);
+    update();
   }
 
   function setupSectionOrder(prefix) {
@@ -548,6 +550,8 @@
 
   function setupHideToggles() {
     const hideCheckboxes = Array.from(document.querySelectorAll('input[type="checkbox"][data-targets]'));
+    const allHide = document.getElementById('all-hide');
+    const initHandlers = !allHide || !allHide.checked;
     hideCheckboxes.forEach(cb => {
       const ids = cb.dataset.targets.split(',').map(id => id.trim());
       const elems = ids.map(id => document.getElementById(id)).filter(Boolean);
@@ -574,9 +578,8 @@
         reflectAllHide();
       };
       cb.addEventListener('change', handler);
-      handler();
+      if (initHandlers) handler();
     });
-    const allHide = document.getElementById('all-hide');
     if (allHide && allHide.checked) applyAllHideState();
     return hideCheckboxes;
   }
@@ -584,11 +587,12 @@
   function applyAllHideState() {
     const allHide = document.getElementById('all-hide');
     if (!allHide) return;
+    const state = allHide.checked;
     const hideCheckboxes = Array.from(
       document.querySelectorAll('input[type="checkbox"][data-targets]')
     );
     hideCheckboxes.forEach(cb => {
-      cb.checked = allHide.checked;
+      cb.checked = state;
       const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
       if (btn) updateButtonState(btn, cb);
       cb.dispatchEvent(new Event('change'));
@@ -596,7 +600,7 @@
     ['pos', 'neg'].forEach(p => {
       const sec = document.getElementById(`${p}-all-hide`);
       if (sec) {
-        sec.checked = allHide.checked;
+        sec.checked = state;
         const btn = document.querySelector(`.toggle-button[data-target="${sec.id}"]`);
         if (btn) updateButtonState(btn, sec);
         sec.dispatchEvent(new Event('change'));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -36,7 +36,8 @@ const {
   rerollRandomOrders,
   setupAdvancedToggle,
   updateStackBlocks,
-  setupSectionOrder
+  setupSectionOrder,
+  setupSectionHide
 } = ui;
 
 describe('Utility functions', () => {
@@ -1083,6 +1084,88 @@ describe('List persistence', () => {
     allHide.checked = false;
     allHide.dispatchEvent(new Event('change'));
     expect(posInput2.style.display).toBe('');
+  });
+
+  test('section all-hide applies to new stack blocks', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="pos-all-hide">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div class="label-row">
+            <label>Stack 1</label>
+            <div class="button-col">
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
+            </div>
+          </div>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        </div>
+      </div>`;
+    setupToggleButtons();
+    setupStackControls();
+    setupHideToggles();
+    setupSectionHide('pos');
+    const secHide = document.getElementById('pos-all-hide');
+    secHide.checked = true;
+    secHide.dispatchEvent(new Event('change'));
+    const stackCb = document.getElementById('pos-stack');
+    stackCb.checked = true;
+    stackCb.dispatchEvent(new Event('change'));
+    const posInput2 = document.getElementById('pos-input-2');
+    expect(posInput2.style.display).toBe('none');
+  });
+
+  test('global hide stays off when section toggled visible before stacking', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-hide">
+      <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+      <input type="checkbox" id="pos-all-hide">
+      <button type="button" class="toggle-button" data-target="pos-all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <select id="pos-select"></select>
+      <select id="pos-order-select"></select>
+      <select id="pos-depth-select"></select>
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <div class="label-row">
+            <label>Stack 1</label>
+            <div class="button-col">
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
+            </div>
+          </div>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+        </div>
+      </div>`;
+    setupToggleButtons();
+    setupStackControls();
+    setupHideToggles();
+    setupSectionHide('pos');
+    const globalHide = document.getElementById('all-hide');
+    globalHide.checked = true;
+    globalHide.dispatchEvent(new Event('change'));
+    const secHide = document.getElementById('pos-all-hide');
+    secHide.checked = false;
+    secHide.dispatchEvent(new Event('change'));
+    expect(globalHide.checked).toBe(false);
+    const stackCb = document.getElementById('pos-stack');
+    stackCb.checked = true;
+    stackCb.dispatchEvent(new Event('change'));
+    const posInput2 = document.getElementById('pos-input-2');
+    expect(posInput2.style.display).toBe('');
+    expect(globalHide.checked).toBe(false);
+    const secBtn = document.querySelector('.toggle-button[data-target="pos-all-hide"]');
+    expect(secBtn.classList.contains('active')).toBe(false);
   });
 
   test('hide button works for dynamically added stack blocks', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -37,7 +37,8 @@ const {
   setupAdvancedToggle,
   updateStackBlocks,
   setupSectionOrder,
-  setupSectionHide
+  setupSectionHide,
+  setupSectionAdvanced
 } = ui;
 
 describe('Utility functions', () => {
@@ -843,6 +844,34 @@ describe('UI interactions', () => {
     const depthSel = document.getElementById('pos-depth-select-2');
     expect(orderSel.style.display).toBe('');
     expect(depthSel.style.display).toBe('');
+  });
+
+  test('global advanced overrides section settings', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
+      <input type="checkbox" id="pos-advanced">
+      <button type="button" class="toggle-button" data-target="pos-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+      <input type="checkbox" id="neg-advanced">
+      <button type="button" class="toggle-button" data-target="neg-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+    `;
+    setupToggleButtons();
+    setupSectionAdvanced('pos');
+    setupSectionAdvanced('neg');
+    setupAdvancedToggle();
+    const globalCb = document.getElementById('advanced-mode');
+    globalCb.checked = true;
+    globalCb.dispatchEvent(new Event('change'));
+    const posCb = document.getElementById('pos-advanced');
+    posCb.checked = false;
+    posCb.dispatchEvent(new Event('change'));
+    globalCb.checked = false;
+    globalCb.dispatchEvent(new Event('change'));
+    globalCb.checked = true;
+    globalCb.dispatchEvent(new Event('change'));
+    expect(posCb.checked).toBe(true);
+    const posBtn = document.querySelector('.toggle-button[data-target="pos-advanced"]');
+    expect(posBtn.classList.contains('active')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- keep global all-hide checkbox synced with actual hidden state
- avoid resetting all-hide when new toggles are initialized
- hold all-hide state during updates to prevent interference
- test that global hide remains off after section override

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f983363048321a695ec82c0fa6c74