### PR TITLE
Add reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Prompt Enhancer helps you create more effective prompts by:
 - **Quick Copy Buttons**: Every textbox has a copy icon that briefly turns blue with a check mark when clicked
 - **Insertion Depths**: Specify numeric lists for modifier insertion positions
 - **State Saving**: Export and reload all current inputs for repeatable output
+- **Reset to Defaults**: Quickly restore the built-in presets and settings
 - **Deterministic Ordering**: Canonical or randomized lists control item ordering
 - **Divider Ordering**: Control divider list order with canonical or random presets
 - **Quick Actions**: One toggle sets all list ordering menus to canonical or randomized

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,7 @@
               <input type="file" id="data-file" accept="application/json" style="display:none">
               <button type="button" id="load-data">Load</button>
               <button type="button" id="save-data">Save</button>
+              <button type="button" id="reset-data">Reset</button>
             </div>
           </div>
         <!-- Hide all toggle -->

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -62,7 +62,20 @@
     }
   }
 
-  const api = { exportData, importData, persist, loadPersisted };
+  function resetData() {
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.removeItem(KEY);
+      } catch (err) {
+        /* ignore */
+      }
+    }
+    if (typeof DEFAULT_DATA !== 'undefined') {
+      importData(DEFAULT_DATA);
+    }
+  }
+
+  const api = { exportData, importData, persist, loadPersisted, resetData };
 
   if (typeof module !== 'undefined') {
     module.exports = api;

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -1010,6 +1010,7 @@
   function setupDataButtons() {
     const saveBtn = document.getElementById('save-data');
     const loadBtn = document.getElementById('load-data');
+    const resetBtn = document.getElementById('reset-data');
     const fileInput = document.getElementById('data-file');
     if (saveBtn) {
       saveBtn.addEventListener('click', () => {
@@ -1022,6 +1023,13 @@
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+      });
+    }
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        if (confirm('Reset all data to defaults?')) {
+          storage.resetData();
+        }
       });
     }
     if (loadBtn && fileInput) {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -30,4 +30,11 @@ describe('Button layout', () => {
       }
     });
   });
+
+  test('load/save section includes reset button', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const reset = dom.window.document.getElementById('reset-data');
+    expect(reset).not.toBeNull();
+  });
 });

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -90,4 +90,21 @@ describe('Storage manager', () => {
     const txt = document.getElementById('base-input').value;
     expect(txt).toBe('z');
   });
+
+  test('resetData clears storage and loads defaults', () => {
+    localStorage.setItem('promptEnhancerData', JSON.stringify({ state: { 'base-input': 'x' } }));
+    global.DEFAULT_DATA = {
+      lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['d'] }] },
+      state: { 'base-input': 'd', 'base-select': 'b' }
+    };
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+    `;
+    lists.importLists({ presets: [] });
+    storage.resetData();
+    const txt = document.getElementById('base-input').value;
+    expect(txt).toBe('d');
+    expect(localStorage.getItem('promptEnhancerData')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add Reset button to load/save section
- implement resetData helper
- wire up Reset button in UI
- verify Reset button in DOM
- test storageManager reset
- document Reset feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fc3229af08321bafccf3325c970f5