### PR TITLE
Add reset feature to restore defaults

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,7 @@
               <input type="file" id="data-file" accept="application/json" style="display:none">
               <button type="button" id="load-data">Load</button>
               <button type="button" id="save-data">Save</button>
+              <button type="button" id="reset-data">Reset</button>
             </div>
           </div>
         <!-- Hide all toggle -->

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -62,7 +62,13 @@
     }
   }
 
-  const api = { exportData, importData, persist, loadPersisted };
+  function reset() {
+    if (typeof DEFAULT_DATA !== 'undefined') {
+      importData(DEFAULT_DATA);
+    }
+  }
+
+  const api = { exportData, importData, persist, loadPersisted, reset };
 
   if (typeof module !== 'undefined') {
     module.exports = api;

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -1010,6 +1010,7 @@
   function setupDataButtons() {
     const saveBtn = document.getElementById('save-data');
     const loadBtn = document.getElementById('load-data');
+    const resetBtn = document.getElementById('reset-data');
     const fileInput = document.getElementById('data-file');
     if (saveBtn) {
       saveBtn.addEventListener('click', () => {
@@ -1041,6 +1042,9 @@
         reader.readAsText(f);
         fileInput.value = '';
       });
+    }
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => storage.reset());
     }
   }
 

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -30,4 +30,11 @@ describe('Button layout', () => {
       }
     });
   });
+
+  test('reset button exists in data section', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const reset = dom.window.document.getElementById('reset-data');
+    expect(reset).not.toBeNull();
+  });
 });

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -90,4 +90,20 @@ describe('Storage manager', () => {
     const txt = document.getElementById('base-input').value;
     expect(txt).toBe('z');
   });
+
+  test('reset loads DEFAULT_DATA', () => {
+    global.DEFAULT_DATA = {
+      lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['d'] }] },
+      state: { 'base-input': 'd', 'base-select': 'b' }
+    };
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+    `;
+    storage.reset();
+    const txt = document.getElementById('base-input').value;
+    expect(txt).toBe('d');
+    const stored = JSON.parse(localStorage.getItem('promptEnhancerData'));
+    expect(stored.state['base-input']).toBe('d');
+  });
 });


### PR DESCRIPTION
## Summary
- add Reset button in Data section of the UI
- implement `reset` method in storage manager
- wire Reset button to call storage reset
- test presence of button in DOM
- test reset functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fc3229af08321bafccf3325c970f5