### PR TITLE
Add reset button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The Prompt Enhancer helps you create more effective prompts by:
 - **Quick Copy Buttons**: Every textbox has a copy icon that briefly turns blue with a check mark when clicked
 - **Insertion Depths**: Specify numeric lists for modifier insertion positions
 - **State Saving**: Export and reload all current inputs for repeatable output
+- **Comprehensive Save**: All lists and text boxes persist so resets are true defaults
+- **Reset to Defaults**: Quickly restore the built-in presets and settings
 - **Deterministic Ordering**: Canonical or randomized lists control item ordering
 - **Divider Ordering**: Control divider list order with canonical or random presets
 - **Quick Actions**: One toggle sets all list ordering menus to canonical or randomized

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,7 @@
               <input type="file" id="data-file" accept="application/json" style="display:none">
               <button type="button" id="load-data">Load</button>
               <button type="button" id="save-data">Save</button>
+              <button type="button" id="reset-data">Reset</button>
             </div>
           </div>
         <!-- Hide all toggle -->

--- a/src/stateManager.js
+++ b/src/stateManager.js
@@ -17,48 +17,16 @@
     el.dispatchEvent(new Event('change'));
   }
 
-  const FIELD_IDS = [
-    'base-input',
-    'base-select',
-    'base-shuffle',
-    'pos-input',
-    'pos-select',
-    'pos-shuffle',
-    'pos-stack',
-    'pos-stack-size',
-    'neg-input',
-    'neg-select',
-    'neg-shuffle',
-    'neg-stack',
-    'neg-stack-size',
-    'neg-include-pos',
-    'divider-input',
-    'divider-select',
-    'divider-shuffle',
-    'length-input',
-    'length-select',
-    'lyrics-input',
-    'lyrics-select',
-    'lyrics-space',
-    'lyrics-remove-parens',
-    'lyrics-remove-brackets',
-    'pos-depth-select',
-    'pos-depth-input',
-    'neg-depth-select',
-    'neg-depth-input',
-    'base-order-select',
-    'base-order-input',
-    'pos-order-select',
-    'pos-order-input',
-    'neg-order-select',
-    'neg-order-input',
-    'divider-order-select',
-    'divider-order-input'
-  ];
+  function getFieldIds() {
+    if (typeof document === 'undefined') return [];
+    return Array.from(
+      document.querySelectorAll('input[id], textarea[id], select[id]')
+    ).map(el => el.id);
+  }
 
   function loadFromDOM() {
     const obj = {};
-    FIELD_IDS.forEach(id => {
+    getFieldIds().forEach(id => {
       const el = typeof document !== 'undefined' && document.getElementById(id);
       if (el) obj[id] = getVal(el);
     });
@@ -69,7 +37,7 @@
 
   function applyToDOM(state) {
     if (!state) return;
-    FIELD_IDS.forEach(id => {
+    getFieldIds().forEach(id => {
       if (Object.prototype.hasOwnProperty.call(state, id)) {
         const el = typeof document !== 'undefined' && document.getElementById(id);
         setVal(el, state[id]);

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -62,7 +62,20 @@
     }
   }
 
-  const api = { exportData, importData, persist, loadPersisted };
+  function resetData() {
+    if (typeof localStorage !== 'undefined') {
+      try {
+        localStorage.removeItem(KEY);
+      } catch (err) {
+        /* ignore */
+      }
+    }
+    if (typeof DEFAULT_DATA !== 'undefined') {
+      importData(DEFAULT_DATA);
+    }
+  }
+
+  const api = { exportData, importData, persist, loadPersisted, resetData };
 
   if (typeof module !== 'undefined') {
     module.exports = api;

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -1007,9 +1007,60 @@
     });
   }
 
+  function applyCurrentPresets() {
+    applyPreset(
+      document.getElementById('neg-select'),
+      document.getElementById('neg-input'),
+      'negative'
+    );
+    applyPreset(
+      document.getElementById('pos-select'),
+      document.getElementById('pos-input'),
+      'positive'
+    );
+    applyPreset(
+      document.getElementById('length-select'),
+      document.getElementById('length-input'),
+      'length'
+    );
+    applyPreset(
+      document.getElementById('divider-select'),
+      document.getElementById('divider-input'),
+      'divider'
+    );
+    applyPreset(
+      document.getElementById('base-select'),
+      document.getElementById('base-input'),
+      'base'
+    );
+    applyPreset(
+      document.getElementById('lyrics-select'),
+      document.getElementById('lyrics-input'),
+      'lyrics'
+    );
+  }
+
+  function resetUI() {
+    const fields = document.querySelectorAll('input[id], textarea[id], select[id]');
+    fields.forEach(el => {
+      if (el.tagName === 'SELECT') {
+        el.selectedIndex = 0;
+      } else if (el.type === 'checkbox') {
+        el.checked = el.defaultChecked;
+      } else {
+        el.value = el.defaultValue || '';
+      }
+      el.dispatchEvent(new Event('change'));
+    });
+    updateStackBlocks('pos', 1);
+    updateStackBlocks('neg', 1);
+    applyCurrentPresets();
+  }
+
   function setupDataButtons() {
     const saveBtn = document.getElementById('save-data');
     const loadBtn = document.getElementById('load-data');
+    const resetBtn = document.getElementById('reset-data');
     const fileInput = document.getElementById('data-file');
     if (saveBtn) {
       saveBtn.addEventListener('click', () => {
@@ -1022,6 +1073,14 @@
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+      });
+    }
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        if (confirm('Reset all data to defaults?')) {
+          storage.resetData();
+          resetUI();
+        }
       });
     }
     if (loadBtn && fileInput) {
@@ -1046,12 +1105,7 @@
 
   function initializeUI() {
     storage.loadPersisted();
-    applyPreset(document.getElementById('neg-select'), document.getElementById('neg-input'), 'negative');
-    applyPreset(document.getElementById('pos-select'), document.getElementById('pos-input'), 'positive');
-    applyPreset(document.getElementById('length-select'), document.getElementById('length-input'), 'length');
-    applyPreset(document.getElementById('divider-select'), document.getElementById('divider-input'), 'divider');
-    applyPreset(document.getElementById('base-select'), document.getElementById('base-input'), 'base');
-    applyPreset(document.getElementById('lyrics-select'), document.getElementById('lyrics-input'), 'lyrics');
+    applyCurrentPresets();
 
     setupPresetListener('neg-select', 'neg-input', 'negative');
     setupPresetListener('pos-select', 'pos-input', 'positive');
@@ -1151,7 +1205,9 @@
     setupSectionHide,
     setupSectionOrder,
     setupSectionAdvanced,
-    initializeUI
+    initializeUI,
+    applyCurrentPresets,
+    resetUI
   };
 
   if (typeof module !== 'undefined') {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -30,4 +30,11 @@ describe('Button layout', () => {
       }
     });
   });
+
+  test('load/save section includes reset button', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const reset = dom.window.document.getElementById('reset-data');
+    expect(reset).not.toBeNull();
+  });
 });

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -106,4 +106,16 @@ describe('State manager integration', () => {
     expect(document.getElementById('pos-depth-input').value).toBe('1,2');
     expect(document.getElementById('neg-depth-input').value).toBe('3');
   });
+
+  test('stacked inputs round trip through state export', () => {
+    const ta = document.createElement('textarea');
+    ta.id = 'pos-input-2';
+    document.body.appendChild(ta);
+    ta.value = 'extra';
+    state.loadFromDOM();
+    const json = state.exportState();
+    ta.value = '';
+    state.importState(JSON.parse(json));
+    expect(document.getElementById('pos-input-2').value).toBe('extra');
+  });
 });

--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -90,4 +90,21 @@ describe('Storage manager', () => {
     const txt = document.getElementById('base-input').value;
     expect(txt).toBe('z');
   });
+
+  test('resetData clears storage and loads defaults', () => {
+    localStorage.setItem('promptEnhancerData', JSON.stringify({ state: { 'base-input': 'x' } }));
+    global.DEFAULT_DATA = {
+      lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['d'] }] },
+      state: { 'base-input': 'd', 'base-select': 'b' }
+    };
+    document.body.innerHTML = `
+      <select id="base-select"></select>
+      <textarea id="base-input"></textarea>
+    `;
+    lists.importLists({ presets: [] });
+    storage.resetData();
+    const txt = document.getElementById('base-input').value;
+    expect(txt).toBe('d');
+    expect(localStorage.getItem('promptEnhancerData')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- add Reset button to load/save section
- implement resetData helper
- wire up Reset button in UI
- verify Reset button in DOM
- test storageManager reset
- document Reset feature
- fix reset to restore UI defaults and capture all fields
- add dynamic state round-trip test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fc3229af08321bafccf3325c970f5