### PR TITLE
Fix depth hide toggles

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -104,7 +104,7 @@
                   <button type="button" id="pos-save-1" class="save-button icon-button" title="Save">&#128190;</button>
             <button type="button" id="pos-reroll-1" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
           <button type="button" class="copy-button icon-button" data-target="pos-input" title="Copy">&#128203;</button>
-                  <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+                  <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
                   <button type="button" class="toggle-button icon-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
                 </div>
               </div>
@@ -166,7 +166,7 @@
                   <button type="button" id="neg-save-1" class="save-button icon-button" title="Save">&#128190;</button>
             <button type="button" id="neg-reroll-1" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
           <button type="button" class="copy-button icon-button" data-target="neg-input" title="Copy">&#128203;</button>
-                  <input type="checkbox" id="neg-hide-1" data-targets="neg-input,neg-order-input" hidden>
+                  <input type="checkbox" id="neg-hide-1" data-targets="neg-input,neg-order-input,neg-depth-input" hidden>
                   <button type="button" class="toggle-button icon-button hide-button" data-target="neg-hide-1" data-on="☰" data-off="✖">☰</button>
                 </div>
               </div>

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -5,6 +5,8 @@
     global.listManager || (typeof require !== 'undefined' && require('./listManager'));
   const storage = global.storageManager || (typeof require !== "undefined" && require("./storageManager"));
 
+  let reflectAllRandomLocked = false;
+
   function guessPrefix(id) {
     const m = id.match(/^([a-z]+)(?:-(?:order|depth))?-select/);
     return m ? m[1] : id.replace(/-select.*$/, '');
@@ -265,6 +267,7 @@
       }
     };
     const updateAll = () => {
+      reflectAllRandomLocked = true;
       const selects = Array.from(
         document.querySelectorAll('[id*="-order-select"], [id*="-depth-select"]')
       );
@@ -281,6 +284,7 @@
           cb.dispatchEvent(new Event('change'));
         }
       });
+      reflectAllRandomLocked = false;
       reflect();
     };
     allRandom.addEventListener('change', updateAll);
@@ -367,6 +371,10 @@
     );
     const allRand = sels.every(s => s.value === 'random');
     const allCan = sels.every(s => s.value === canonicalFor(s));
+    if (!reflectAllRandomLocked) {
+      const globalCb = document.getElementById('all-random');
+      if (globalCb) globalCb.checked = allRand;
+    }
     const btn = document.querySelector('.toggle-button[data-target="all-random"]');
     reflectToggleState(btn, allRand, !allCan && !allRand);
   }
@@ -381,6 +389,7 @@
     ].map(p => p.select).filter(Boolean);
     const allRand = sels.every(s => s.value === 'random');
     const allCan = sels.every(s => s.value === canonicalFor(s));
+    cb.checked = allRand;
     const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
     reflectToggleState(btn, allRand, !allCan && !allRand);
   }
@@ -390,6 +399,8 @@
     if (!secs.length) return;
     const allOn = secs.every(cb => cb.checked);
     const allOff = secs.every(cb => !cb.checked);
+    const globalCb = document.getElementById('advanced-mode');
+    if (globalCb) globalCb.checked = allOn;
     const btn = document.querySelector('.toggle-button[data-target="advanced-mode"]');
     reflectToggleState(btn, allOn, !allOff && !allOn);
   }

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -810,7 +810,7 @@
       const hideCb = document.createElement('input');
       hideCb.type = 'checkbox';
       hideCb.id = `${prefix}-hide-${idx}`;
-      hideCb.dataset.targets = `${prefix}-input-${idx},${prefix}-order-input-${idx}`;
+      hideCb.dataset.targets = `${prefix}-input-${idx},${prefix}-order-input-${idx},${prefix}-depth-input-${idx}`;
       hideCb.hidden = true;
       btnCol.appendChild(hideCb);
       const hideBtn = document.createElement('button');

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -219,6 +219,16 @@
     }
   }
 
+  function reflectToggleState(btn, active, indeterminate) {
+    if (!btn) return;
+    btn.classList.remove('active', 'indeterminate');
+    if (active) btn.classList.add('active');
+    else if (indeterminate) btn.classList.add('indeterminate');
+    if (btn.dataset.on && btn.dataset.off) {
+      btn.textContent = active ? btn.dataset.on : btn.dataset.off;
+    }
+  }
+
   function setupToggleButtons() {
     document.querySelectorAll('.toggle-button').forEach(btn => {
       const target = btn.dataset.target;
@@ -334,11 +344,7 @@
       idx++;
     }
     const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
-    if (btn) {
-      btn.classList.remove('active', 'indeterminate');
-      if (all) btn.classList.add('active');
-      else if (any) btn.classList.add('indeterminate');
-    }
+    reflectToggleState(btn, all, any && !all);
   }
 
   function reflectAllHide() {
@@ -350,11 +356,7 @@
     const globalCb = document.getElementById('all-hide');
     if (globalCb) globalCb.checked = all;
     const btn = document.querySelector('.toggle-button[data-target="all-hide"]');
-    if (btn) {
-      btn.classList.remove('active', 'indeterminate');
-      if (all) btn.classList.add('active');
-      else if (any) btn.classList.add('indeterminate');
-    }
+    reflectToggleState(btn, all, any && !all);
   }
 
   function reflectAllRandom() {
@@ -366,11 +368,7 @@
     const allRand = sels.every(s => s.value === 'random');
     const allCan = sels.every(s => s.value === canonicalFor(s));
     const btn = document.querySelector('.toggle-button[data-target="all-random"]');
-    if (btn) {
-      btn.classList.remove('active', 'indeterminate');
-      if (allRand) btn.classList.add('active');
-      else if (!allCan) btn.classList.add('indeterminate');
-    }
+    reflectToggleState(btn, allRand, !allCan && !allRand);
   }
 
   function reflectSectionOrder(prefix) {
@@ -384,11 +382,7 @@
     const allRand = sels.every(s => s.value === 'random');
     const allCan = sels.every(s => s.value === canonicalFor(s));
     const btn = document.querySelector(`.toggle-button[data-target="${cb.id}"]`);
-    if (btn) {
-      btn.classList.remove('active', 'indeterminate');
-      if (allRand) btn.classList.add('active');
-      else if (!allCan) btn.classList.add('indeterminate');
-    }
+    reflectToggleState(btn, allRand, !allCan && !allRand);
   }
 
   function reflectGlobalAdvanced() {
@@ -397,11 +391,7 @@
     const allOn = secs.every(cb => cb.checked);
     const allOff = secs.every(cb => !cb.checked);
     const btn = document.querySelector('.toggle-button[data-target="advanced-mode"]');
-    if (btn) {
-      btn.classList.remove('active', 'indeterminate');
-      if (allOn) btn.classList.add('active');
-      else if (!allOff) btn.classList.add('indeterminate');
-    }
+    reflectToggleState(btn, allOn, !allOff && !allOn);
   }
 
   function setupSectionHide(prefix) {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -37,4 +37,13 @@ describe('Button layout', () => {
     const reset = dom.window.document.getElementById('reset-data');
     expect(reset).not.toBeNull();
   });
+
+  test('depth hide toggles include depth textbox', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    const posHide = dom.window.document.getElementById('pos-hide-1');
+    const negHide = dom.window.document.getElementById('neg-hide-1');
+    expect(posHide.dataset.targets).toContain('pos-depth-input');
+    expect(negHide.dataset.targets).toContain('neg-depth-input');
+  });
 });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1423,4 +1423,113 @@ describe('List persistence', () => {
     cb.dispatchEvent(new Event('change'));
     expect(btn.textContent).toBe('All visible');
   });
+
+  test('global random checkbox syncs with selects', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-random">
+      <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <input type="checkbox" id="pos-order-random">
+      <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <input type="checkbox" id="neg-order-random">
+      <button type="button" class="toggle-button" data-target="neg-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="neg-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+      <select id="neg-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+    `;
+    setupSectionOrder('pos');
+    setupSectionOrder('neg');
+    setupToggleButtons();
+    setupShuffleAll();
+    const ps = document.getElementById('pos-order-select');
+    const ns = document.getElementById('neg-order-select');
+    const pd = document.getElementById('pos-depth-select');
+    const nd = document.getElementById('neg-depth-select');
+    ps.value = 'random';
+    ps.dispatchEvent(new Event('change'));
+    ns.value = 'random';
+    ns.dispatchEvent(new Event('change'));
+    pd.value = 'random';
+    pd.dispatchEvent(new Event('change'));
+    nd.value = 'random';
+    nd.dispatchEvent(new Event('change'));
+    expect(document.getElementById('all-random').checked).toBe(true);
+    const btn = document.querySelector('.toggle-button[data-target="all-random"]');
+    btn.click();
+    expect(ps.value).toBe('canonical');
+    expect(ns.value).toBe('canonical');
+    expect(pd.value).toBe('prepend');
+    expect(nd.value).toBe('prepend');
+  });
+
+  test('section random checkbox syncs with selects', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="pos-order-random">
+      <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+    `;
+    setupSectionOrder('pos');
+    setupToggleButtons();
+    const sel = document.getElementById('pos-order-select');
+    const dep = document.getElementById('pos-depth-select');
+    sel.value = 'random';
+    sel.dispatchEvent(new Event('change'));
+    dep.value = 'random';
+    dep.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-order-random').checked).toBe(true);
+    const btn = document.querySelector('.toggle-button[data-target="pos-order-random"]');
+    btn.click();
+    expect(sel.value).toBe('canonical');
+    expect(dep.value).toBe('prepend');
+  });
+
+  test('global hide checkbox syncs with section hides', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-hide">
+      <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+      <input type="checkbox" id="hide-1" data-targets="foo" hidden>
+      <input type="checkbox" id="hide-2" data-targets="bar" hidden>
+      <div id="foo"></div>
+      <div id="bar"></div>
+    `;
+    setupToggleButtons();
+    setupHideToggles();
+    document.getElementById('all-hide').addEventListener('change', applyAllHideState);
+    const h1 = document.getElementById('hide-1');
+    const h2 = document.getElementById('hide-2');
+    h1.checked = true;
+    h1.dispatchEvent(new Event('change'));
+    h2.checked = true;
+    h2.dispatchEvent(new Event('change'));
+    expect(document.getElementById('all-hide').checked).toBe(true);
+    const btn = document.querySelector('.toggle-button[data-target="all-hide"]');
+    btn.click();
+    expect(h1.checked).toBe(false);
+    expect(h2.checked).toBe(false);
+  });
+
+  test('advanced mode checkbox syncs with sections', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
+      <input type="checkbox" id="pos-advanced">
+      <button type="button" class="toggle-button" data-target="pos-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+      <input type="checkbox" id="neg-advanced">
+      <button type="button" class="toggle-button" data-target="neg-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+    `;
+    setupToggleButtons();
+    setupSectionAdvanced('pos');
+    setupSectionAdvanced('neg');
+    setupAdvancedToggle();
+    document.getElementById('pos-advanced').checked = true;
+    document.getElementById('pos-advanced').dispatchEvent(new Event('change'));
+    document.getElementById('neg-advanced').checked = true;
+    document.getElementById('neg-advanced').dispatchEvent(new Event('change'));
+    expect(document.getElementById('advanced-mode').checked).toBe(true);
+    const btn = document.querySelector('.toggle-button[data-target="advanced-mode"]');
+    btn.click();
+    expect(document.getElementById('pos-advanced').checked).toBe(false);
+    expect(document.getElementById('neg-advanced').checked).toBe(false);
+  });
 });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1356,4 +1356,71 @@ describe('List persistence', () => {
     dsel.dispatchEvent(new Event('change'));
     expect(btn.classList.contains('indeterminate')).toBe(true);
   });
+
+  test('section random button text updates with state', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="pos-order-random">
+      <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+    `;
+    setupSectionOrder('pos');
+    const btn = document.querySelector('.toggle-button[data-target="pos-order-random"]');
+    const sel = document.getElementById('pos-order-select');
+    const dsel = document.getElementById('pos-depth-select');
+    sel.value = 'random';
+    sel.dispatchEvent(new Event('change'));
+    dsel.value = 'random';
+    dsel.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('Randomized');
+    dsel.value = 'prepend';
+    dsel.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('Canonical');
+  });
+
+  test('global random button text updates with state', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-random">
+      <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <input type="checkbox" id="pos-order-random">
+      <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <input type="checkbox" id="neg-order-random">
+      <button type="button" class="toggle-button" data-target="neg-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <select id="neg-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+    `;
+    setupSectionOrder('pos');
+    setupSectionOrder('neg');
+    setupShuffleAll();
+    const btn = document.querySelector('.toggle-button[data-target="all-random"]');
+    const ps = document.getElementById('pos-order-select');
+    const ns = document.getElementById('neg-order-select');
+    ps.value = 'random';
+    ps.dispatchEvent(new Event('change'));
+    ns.value = 'random';
+    ns.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('Randomized');
+    ns.value = 'canonical';
+    ns.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('Canonical');
+  });
+
+  test('global hide button text updates when all hidden', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="all-hide">
+      <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+      <input type="checkbox" id="hide-1" data-targets="foo" hidden>
+      <div id="foo"></div>
+    `;
+    setupToggleButtons();
+    setupHideToggles();
+    const btn = document.querySelector('.toggle-button[data-target="all-hide"]');
+    const cb = document.getElementById('hide-1');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('All hidden');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change'));
+    expect(btn.textContent).toBe('All visible');
+  });
 });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1068,6 +1068,7 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1"></div>
       </div>`;
@@ -1086,12 +1087,13 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1">
           <div class="label-row">
             <label>Stack 1</label>
             <div class="button-col">
-              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
               <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -1109,10 +1111,13 @@ describe('List persistence', () => {
     posStack.checked = true;
     posStack.dispatchEvent(new Event('change'));
     const posInput2 = document.getElementById('pos-input-2');
+    const posDepth2 = document.getElementById('pos-depth-input-2');
     expect(posInput2.style.display).toBe('none');
+    expect(posDepth2.style.display).toBe('none');
     allHide.checked = false;
     allHide.dispatchEvent(new Event('change'));
     expect(posInput2.style.display).toBe('');
+    expect(posDepth2.style.display).toBe('');
   });
 
   test('section all-hide applies to new stack blocks', () => {
@@ -1124,12 +1129,13 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1">
           <div class="label-row">
             <label>Stack 1</label>
             <div class="button-col">
-              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
               <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -1148,7 +1154,9 @@ describe('List persistence', () => {
     stackCb.checked = true;
     stackCb.dispatchEvent(new Event('change'));
     const posInput2 = document.getElementById('pos-input-2');
+    const posDepth2 = document.getElementById('pos-depth-input-2');
     expect(posInput2.style.display).toBe('none');
+    expect(posDepth2.style.display).toBe('none');
   });
 
   test('global hide stays off when section toggled visible before stacking', () => {
@@ -1163,12 +1171,13 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1">
           <div class="label-row">
             <label>Stack 1</label>
             <div class="button-col">
-              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
               <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -1191,7 +1200,9 @@ describe('List persistence', () => {
     stackCb.checked = true;
     stackCb.dispatchEvent(new Event('change'));
     const posInput2 = document.getElementById('pos-input-2');
+    const posDepth2 = document.getElementById('pos-depth-input-2');
     expect(posInput2.style.display).toBe('');
+    expect(posDepth2.style.display).toBe('');
     expect(globalHide.checked).toBe(false);
     const secBtn = document.querySelector('.toggle-button[data-target="pos-all-hide"]');
     expect(secBtn.classList.contains('active')).toBe(false);
@@ -1205,12 +1216,13 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1">
           <div class="label-row">
             <label>Stack 1</label>
             <div class="button-col">
-              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
               <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -1228,8 +1240,10 @@ describe('List persistence', () => {
     expect(hideBtn).not.toBeNull();
     hideBtn.click();
     expect(document.getElementById('pos-input-2').style.display).toBe('none');
+    expect(document.getElementById('pos-depth-input-2').style.display).toBe('none');
     hideBtn.click();
     expect(document.getElementById('pos-input-2').style.display).toBe('');
+    expect(document.getElementById('pos-depth-input-2').style.display).toBe('');
   });
 
   test('hide buttons still work after toggling stacks on and off', () => {
@@ -1240,12 +1254,13 @@ describe('List persistence', () => {
       <select id="pos-select"></select>
       <select id="pos-order-select"></select>
       <select id="pos-depth-select"></select>
+      <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
       <div id="pos-stack-container">
         <div class="stack-block" id="pos-stack-1">
           <div class="label-row">
             <label>Stack 1</label>
             <div class="button-col">
-              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input" hidden>
+              <input type="checkbox" id="pos-hide-1" data-targets="pos-input,pos-order-input,pos-depth-input" hidden>
               <button type="button" class="toggle-button hide-button" data-target="pos-hide-1" data-on="☰" data-off="✖">☰</button>
             </div>
           </div>
@@ -1265,9 +1280,11 @@ describe('List persistence', () => {
     hideCb.checked = true;
     hideCb.dispatchEvent(new Event('change'));
     expect(document.getElementById('pos-input').style.display).toBe('none');
+    expect(document.getElementById('pos-depth-input').style.display).toBe('none');
     hideCb.checked = false;
     hideCb.dispatchEvent(new Event('change'));
     expect(document.getElementById('pos-input').style.display).toBe('');
+    expect(document.getElementById('pos-depth-input').style.display).toBe('');
   });
 
   test('stack toggle button can turn stack off again', () => {


### PR DESCRIPTION
## Summary
- hide depth inputs when using hide toggles
- ensure dynamically generated stack blocks use same behaviour
- cover hide toggle logic with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fd3569c0483218f1e0a8c144c4afb