### PR TITLE
Fix advanced mode reset on stack enable

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -483,6 +483,24 @@
     reflectGlobalAdvanced();
   }
 
+  function refreshSectionAdvanced(prefix) {
+    const cb = document.getElementById(`${prefix}-advanced`);
+    if (!cb) return;
+    const adv = cb.checked;
+    const setDisplay = (el, show) => { if (el) el.style.display = show ? '' : 'none'; };
+    document.querySelectorAll(`[id^="${prefix}-order-select"]`).forEach(el => setDisplay(el, adv));
+    document.querySelectorAll(`[id^="${prefix}-depth-select"]`).forEach(el => setDisplay(el, adv));
+    document.querySelectorAll(`[id^="${prefix}-order-input"]`).forEach(el => {
+      if (el.parentElement && el.parentElement.classList.contains('input-row')) setDisplay(el.parentElement, adv);
+    });
+    document.querySelectorAll(`[id^="${prefix}-depth-input"]`).forEach(el => {
+      if (el.parentElement && el.parentElement.classList.contains('input-row')) setDisplay(el.parentElement, adv);
+    });
+    document.querySelectorAll(`[id^="${prefix}-order-container"]`).forEach(el => setDisplay(el, adv));
+    document.querySelectorAll(`[id^="${prefix}-depth-container"]`).forEach(el => setDisplay(el, adv));
+    (rerollUpdaters[prefix] || []).forEach(fn => fn());
+  }
+
   const rerollUpdaters = {};
 
   function setupAdvancedToggle() {
@@ -896,8 +914,12 @@
     setupSectionHide(prefix);
     setupSectionOrder(prefix);
     setupSectionAdvanced(prefix);
-    const adv = document.getElementById('advanced-mode');
-    if (adv) adv.dispatchEvent(new Event('change'));
+    if (document.getElementById(`${prefix}-advanced`)) {
+      refreshSectionAdvanced(prefix);
+    } else {
+      const adv = document.getElementById('advanced-mode');
+      if (adv) adv.dispatchEvent(new Event('change'));
+    }
   }
 
   function setupRerollButton(btnId, selectId) {

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -897,7 +897,7 @@
     setupSectionOrder(prefix);
     setupSectionAdvanced(prefix);
     const adv = document.getElementById('advanced-mode');
-    if (adv && !adv.checked) adv.dispatchEvent(new Event('change'));
+    if (adv) adv.dispatchEvent(new Event('change'));
   }
 
   function setupRerollButton(btnId, selectId) {

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -914,12 +914,14 @@
     setupSectionHide(prefix);
     setupSectionOrder(prefix);
     setupSectionAdvanced(prefix);
-    if (document.getElementById(`${prefix}-advanced`)) {
-      refreshSectionAdvanced(prefix);
-    } else {
-      const adv = document.getElementById('advanced-mode');
-      if (adv) adv.dispatchEvent(new Event('change'));
-    }
+    ['pos', 'neg'].forEach(p => {
+      if (document.getElementById(`${p}-advanced`)) {
+        refreshSectionAdvanced(p);
+      } else {
+        const adv = document.getElementById('advanced-mode');
+        if (adv) adv.dispatchEvent(new Event('change'));
+      }
+    });
   }
 
   function setupRerollButton(btnId, selectId) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -905,6 +905,45 @@ describe('UI interactions', () => {
     const posBtn = document.querySelector('.toggle-button[data-target="pos-advanced"]');
     expect(posBtn.classList.contains('active')).toBe(true);
   });
+
+  test('enabling negative stack keeps positive advanced state', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <input type="checkbox" id="pos-advanced">
+      <input type="checkbox" id="neg-advanced">
+      <input type="checkbox" id="neg-stack">
+      <select id="neg-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-shuffle">
+      <div id="neg-stack-container">
+        <div class="stack-block" id="neg-stack-1">
+          <select id="neg-select"></select>
+          <div class="input-row"><textarea id="neg-input"></textarea></div>
+          <div id="neg-order-container">
+            <select id="neg-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="neg-order-input"></textarea></div>
+          </div>
+          <div id="neg-depth-container">
+            <select id="neg-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="neg-depth-input"></textarea></div>
+          </div>
+        </div>
+      </div>
+    `;
+    setupSectionAdvanced('pos');
+    setupSectionAdvanced('neg');
+    setupAdvancedToggle();
+    setupStackControls();
+    const globalAdv = document.getElementById('advanced-mode');
+    globalAdv.checked = true;
+    globalAdv.dispatchEvent(new Event('change'));
+    const posAdv = document.getElementById('pos-advanced');
+    posAdv.checked = false;
+    posAdv.dispatchEvent(new Event('change'));
+    const negStack = document.getElementById('neg-stack');
+    negStack.checked = true;
+    negStack.dispatchEvent(new Event('change'));
+    expect(posAdv.checked).toBe(false);
+  });
 });
 
 describe('List persistence', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -944,6 +944,86 @@ describe('UI interactions', () => {
     negStack.dispatchEvent(new Event('change'));
     expect(posAdv.checked).toBe(false);
   });
+
+  test('enabling positive stack keeps negative advanced state', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <input type="checkbox" id="pos-advanced">
+      <input type="checkbox" id="neg-advanced">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <select id="pos-select"></select>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div id="pos-order-container">
+            <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+          </div>
+          <div id="pos-depth-container">
+            <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
+          </div>
+        </div>
+      </div>
+    `;
+    setupSectionAdvanced('pos');
+    setupSectionAdvanced('neg');
+    setupAdvancedToggle();
+    setupStackControls();
+    const globalAdv = document.getElementById('advanced-mode');
+    globalAdv.checked = true;
+    globalAdv.dispatchEvent(new Event('change'));
+    const negAdv = document.getElementById('neg-advanced');
+    negAdv.checked = false;
+    negAdv.dispatchEvent(new Event('change'));
+    const posStack = document.getElementById('pos-stack');
+    posStack.checked = true;
+    posStack.dispatchEvent(new Event('change'));
+    expect(negAdv.checked).toBe(false);
+  });
+
+  test('disabling negative stack keeps positive advanced state', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <input type="checkbox" id="pos-advanced">
+      <input type="checkbox" id="neg-advanced">
+      <input type="checkbox" id="neg-stack">
+      <select id="neg-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="neg-shuffle">
+      <div id="neg-stack-container">
+        <div class="stack-block" id="neg-stack-1">
+          <select id="neg-select"></select>
+          <div class="input-row"><textarea id="neg-input"></textarea></div>
+          <div id="neg-order-container">
+            <select id="neg-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="neg-order-input"></textarea></div>
+          </div>
+          <div id="neg-depth-container">
+            <select id="neg-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="neg-depth-input"></textarea></div>
+          </div>
+        </div>
+      </div>
+    `;
+    setupSectionAdvanced('pos');
+    setupSectionAdvanced('neg');
+    setupAdvancedToggle();
+    setupStackControls();
+    const globalAdv = document.getElementById('advanced-mode');
+    globalAdv.checked = true;
+    globalAdv.dispatchEvent(new Event('change'));
+    const posAdv = document.getElementById('pos-advanced');
+    posAdv.checked = false;
+    posAdv.dispatchEvent(new Event('change'));
+    const negStack = document.getElementById('neg-stack');
+    negStack.checked = true;
+    negStack.dispatchEvent(new Event('change'));
+    negStack.checked = false;
+    negStack.dispatchEvent(new Event('change'));
+    expect(posAdv.checked).toBe(false);
+  });
 });
 
 describe('List persistence', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -846,6 +846,38 @@ describe('UI interactions', () => {
     expect(depthSel.style.display).toBe('');
   });
 
+  test('advanced mode stays on after enabling stack', () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="advanced-mode">
+      <input type="checkbox" id="pos-stack">
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <input type="checkbox" id="pos-shuffle">
+      <div id="pos-stack-container">
+        <div class="stack-block" id="pos-stack-1">
+          <select id="pos-select"></select>
+          <div class="input-row"><textarea id="pos-input"></textarea></div>
+          <div id="pos-order-container">
+            <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+          </div>
+          <div id="pos-depth-container">
+            <select id="pos-depth-select"><option value="prepend">p</option><option value="random">r</option></select>
+            <div class="input-row"><textarea id="pos-depth-input"></textarea></div>
+          </div>
+        </div>
+      </div>
+    `;
+    setupAdvancedToggle();
+    setupStackControls();
+    const adv = document.getElementById('advanced-mode');
+    adv.checked = true;
+    adv.dispatchEvent(new Event('change'));
+    const cb = document.getElementById('pos-stack');
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change'));
+    expect(adv.checked).toBe(true);
+  });
+
   test('global advanced overrides section settings', () => {
     document.body.innerHTML = `
       <input type="checkbox" id="advanced-mode">


### PR DESCRIPTION
## Summary
- ensure advanced toggle state re-applies when changing stack count
- test that enabling a stack doesn't disable advanced mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68702c804c348321ab2b3c538cff4c3e