### PR TITLE
Fix canonical order handling

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -669,9 +669,7 @@
     const prefix = guessPrefix(selectId);
     const update = () => {
       const items = getItems();
-      if (select.value === 'canonical') {
-        input.value = items.map((_, i) => i).join(', ');
-      } else if (select.value === 'random') {
+      if (select.value === 'canonical' || select.value === 'random') {
         input.value = '';
       } else if (lists.ORDER_PRESETS[select.value]) {
         input.value = lists.ORDER_PRESETS[select.value].join(', ');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1608,4 +1608,22 @@ describe('List persistence', () => {
     cb.dispatchEvent(new Event('change'));
     expect(btn.textContent).toBe('All visible');
   });
+
+  test('canonical base order adapts to input changes', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a. b.</textarea>
+    `;
+    setupOrderControl('base-order-select', 'base-order-input', () =>
+      utils.parseInput(document.getElementById('base-input').value, true)
+    );
+    const select = document.getElementById('base-order-select');
+    expect(select.value).toBe('canonical');
+    expect(document.getElementById('base-order-input').value).toBe('');
+    document.getElementById('base-input').value = 'a. b. c.';
+    const items = utils.parseInput(document.getElementById('base-input').value, true);
+    const order = utils.parseOrderInput(document.getElementById('base-order-input').value);
+    expect(utils.applyOrder(items, order)).toEqual(items);
+  });
 });


### PR DESCRIPTION
## Summary
- canonical order no longer stores an index list
- add regression test for canonical base order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870d0fccf2c8321a7fe108396776206