### PR TITLE
Fix canonical order refresh bug

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -662,7 +662,7 @@
   }
 
 
-  function setupOrderControl(selectId, inputId, getItems) {
+  function setupOrderControl(selectId, inputId, getItems, watchId) {
     const select = document.getElementById(selectId);
     const input = document.getElementById(inputId);
     if (!select || !input) return;
@@ -679,6 +679,14 @@
       if (rerollUpdaters[prefix]) rerollUpdaters[prefix].forEach(fn => fn());
     };
     select.addEventListener('change', update);
+    if (watchId) {
+      const src = document.getElementById(watchId);
+      if (src) {
+        src.addEventListener('input', () => {
+          if (select.value === 'canonical') update();
+        });
+      }
+    }
     update();
   }
 
@@ -900,7 +908,7 @@
       container.appendChild(block);
       setupPresetListener(sel.id, ta.id, type);
       applyPreset(sel, ta, type);
-      setupOrderControl(orderSel.id, oTa.id, () => utils.parseInput(ta.value));
+      setupOrderControl(orderSel.id, oTa.id, () => utils.parseInput(ta.value), ta.id);
       setupDepthControl(depthSel.id, dTa.id);
       setupRerollButton(rerollBtn.id, orderSel.id);
     }
@@ -1133,17 +1141,29 @@
     populateDepthOptions(document.getElementById('pos-depth-select'));
     populateDepthOptions(document.getElementById('neg-depth-select'));
 
-    setupOrderControl('base-order-select', 'base-order-input', () =>
-      utils.parseInput(document.getElementById('base-input').value, true)
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
     );
-    setupOrderControl('pos-order-select', 'pos-order-input', () =>
-      utils.parseInput(document.getElementById('pos-input').value)
+    setupOrderControl(
+      'pos-order-select',
+      'pos-order-input',
+      () => utils.parseInput(document.getElementById('pos-input').value),
+      'pos-input'
     );
-    setupOrderControl('neg-order-select', 'neg-order-input', () =>
-      utils.parseInput(document.getElementById('neg-input').value)
+    setupOrderControl(
+      'neg-order-select',
+      'neg-order-input',
+      () => utils.parseInput(document.getElementById('neg-input').value),
+      'neg-input'
     );
-    setupOrderControl('divider-order-select', 'divider-order-input', () =>
-      utils.parseDividerInput(document.getElementById('divider-input').value || '')
+    setupOrderControl(
+      'divider-order-select',
+      'divider-order-input',
+      () => utils.parseDividerInput(document.getElementById('divider-input').value || ''),
+      'divider-input'
     );
     setupDepthControl('pos-depth-select', 'pos-depth-input');
     setupDepthControl('neg-depth-select', 'neg-depth-input');

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -55,6 +55,8 @@
       inputEl.value = list[0] || '';
     }
     inputEl.disabled = false;
+    inputEl.dispatchEvent(new Event('input'));
+    inputEl.dispatchEvent(new Event('change'));
   }
 
   function setupPresetListener(selectId, inputId, type) {
@@ -1092,12 +1094,15 @@
     fields.forEach(el => {
       if (el.tagName === 'SELECT') {
         el.selectedIndex = 0;
+        el.dispatchEvent(new Event('change'));
       } else if (el.type === 'checkbox') {
         el.checked = el.defaultChecked;
+        el.dispatchEvent(new Event('change'));
       } else {
         el.value = el.defaultValue || '';
+        el.dispatchEvent(new Event('input'));
+        el.dispatchEvent(new Event('change'));
       }
-      el.dispatchEvent(new Event('change'));
     });
     updateStackBlocks('pos', 1);
     updateStackBlocks('neg', 1);

--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -686,14 +686,17 @@
     if (watchId) {
       const src = document.getElementById(watchId);
       if (src) {
-        src.addEventListener('input', () => {
+        const handler = () => {
           if (
             select.value === 'canonical' ||
             select.value === 'random' ||
             lists.ORDER_PRESETS[select.value]
-          )
+          ) {
             update();
-        });
+          }
+        };
+        src.addEventListener('input', handler);
+        src.addEventListener('change', handler);
       }
     }
     update();
@@ -759,7 +762,7 @@
     select.addEventListener('change', update);
     const src = document.getElementById(watchId);
     if (src) {
-      src.addEventListener('input', () => {
+      const handler = () => {
         if (
           select.value === 'prepend' ||
           select.value === 'append' ||
@@ -768,7 +771,9 @@
         ) {
           update();
         }
-      });
+      };
+      src.addEventListener('input', handler);
+      src.addEventListener('change', handler);
     }
     update();
   }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -539,6 +539,27 @@ describe('UI interactions', () => {
     expect(document.getElementById('base-order-input').value).toBe('1, 0');
   });
 
+  test('canonical base order updates when base input changes', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a</textarea>
+    `;
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'a,b,c';
+    baseInput.dispatchEvent(new Event('input'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
   test('rerollRandomOrders handles multiple order controls', () => {
     document.body.innerHTML = `
       <select id="pos-order-select">

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -39,7 +39,8 @@ const {
   setupSectionOrder,
   setupSectionHide,
   setupSectionAdvanced,
-  setupDepthControl
+  setupDepthControl,
+  setupPresetListener
 } = ui;
 
 describe('Utility functions', () => {
@@ -612,6 +613,57 @@ describe('UI interactions', () => {
     baseInput.value = 'foo,baz qux quux';
     baseInput.dispatchEvent(new Event('input'));
     expect(document.getElementById('pos-depth-input').value).toBe('1, 3');
+  });
+
+  test('base order updates when selecting a preset', () => {
+    importLists({
+      presets: [
+        { id: 'b', title: 'b', type: 'base', items: ['a', 'b', 'c'] }
+      ]
+    });
+    document.body.innerHTML = `
+      <select id="base-select"><option value="b">b</option></select>
+      <textarea id="base-input"></textarea>
+      <select id="base-order-select"><option value="canonical">c</option></select>
+      <textarea id="base-order-input"></textarea>
+    `;
+    setupPresetListener('base-select', 'base-input', 'base');
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const sel = document.getElementById('base-select');
+    sel.value = 'b';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
+  test('depth updates when selecting a base preset', () => {
+    importLists({
+      presets: [
+        { id: 'b2', title: 'b2', type: 'base', items: ['foo bar', 'baz qux quux'] }
+      ]
+    });
+    document.body.innerHTML = `
+      <select id="base-select"><option value="b2">b2</option></select>
+      <textarea id="base-input"></textarea>
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+    `;
+    setupPresetListener('base-select', 'base-input', 'base');
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const depthSel = document.getElementById('pos-depth-select');
+    depthSel.value = 'append';
+    depthSel.dispatchEvent(new Event('change'));
+    const baseSel = document.getElementById('base-select');
+    baseSel.value = 'b2';
+    baseSel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('2, 3');
   });
 
   test('rerollRandomOrders handles multiple order controls', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -565,6 +565,26 @@ describe('UI interactions', () => {
     expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
   });
 
+  test('canonical base order updates on change events', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select">
+        <option value="canonical">c</option>
+      </select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a</textarea>
+    `;
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'a,b,c';
+    baseInput.dispatchEvent(new Event('change'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
   test('random base order updates when base input changes', () => {
     document.body.innerHTML = `
       <select id="base-order-select">
@@ -612,6 +632,24 @@ describe('UI interactions', () => {
     const baseInput = document.getElementById('base-input');
     baseInput.value = 'foo,baz qux quux';
     baseInput.dispatchEvent(new Event('input'));
+    expect(document.getElementById('pos-depth-input').value).toBe('1, 3');
+  });
+
+  test('append depth updates on change events', () => {
+    document.body.innerHTML = `
+      <select id="pos-depth-select">
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="base-input">foo bar,baz</textarea>
+    `;
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const sel = document.getElementById('pos-depth-select');
+    sel.value = 'append';
+    sel.dispatchEvent(new Event('change'));
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'foo,baz qux quux';
+    baseInput.dispatchEvent(new Event('change'));
     expect(document.getElementById('pos-depth-input').value).toBe('1, 3');
   });
 


### PR DESCRIPTION
## Summary
- refresh canonical ordering when source text changes
- watch order sources in all setupOrderControl calls
- test canonical base order refreshes after editing base prompt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687101f5e0e48321af9abd87e8ae4b31