### PR TITLE
Fix depth controls updating on change events

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -55,6 +55,8 @@
       inputEl.value = list[0] || '';
     }
     inputEl.disabled = false;
+    inputEl.dispatchEvent(new Event('input'));
+    inputEl.dispatchEvent(new Event('change'));
   }
 
   function setupPresetListener(selectId, inputId, type) {
@@ -662,7 +664,7 @@
   }
 
 
-  function setupOrderControl(selectId, inputId, getItems) {
+  function setupOrderControl(selectId, inputId, getItems, watchIds) {
     const select = document.getElementById(selectId);
     const input = document.getElementById(inputId);
     if (!select || !input) return;
@@ -672,13 +674,32 @@
       if (select.value === 'canonical') {
         input.value = items.map((_, i) => i).join(', ');
       } else if (select.value === 'random') {
-        input.value = '';
+        const arr = items.map((_, i) => i);
+        utils.shuffle(arr);
+        input.value = arr.join(', ');
       } else if (lists.ORDER_PRESETS[select.value]) {
         input.value = lists.ORDER_PRESETS[select.value].join(', ');
       }
       if (rerollUpdaters[prefix]) rerollUpdaters[prefix].forEach(fn => fn());
     };
     select.addEventListener('change', update);
+    const ids = Array.isArray(watchIds) ? watchIds : [watchIds];
+    ids.forEach(id => {
+      const src = document.getElementById(id);
+      if (src) {
+        const handler = () => {
+          if (
+            select.value === 'canonical' ||
+            select.value === 'random' ||
+            lists.ORDER_PRESETS[select.value]
+          ) {
+            update();
+          }
+        };
+        src.addEventListener('input', handler);
+        src.addEventListener('change', handler);
+      }
+    });
     update();
   }
 
@@ -702,7 +723,7 @@
   }
 
 
-  function setupDepthControl(selectId, inputId) {
+  function setupDepthControl(selectId, inputId, watchIds = 'base-input') {
     const select = document.getElementById(selectId);
     const input = document.getElementById(inputId);
     const baseInput = document.getElementById('base-input');
@@ -711,21 +732,26 @@
     const build = mode => {
       const bases = utils.parseInput(baseInput.value, true);
       if (!bases.length) {
-        input.value = mode === 'prepend' ? '0' : '';
-        return;
-      }
-      if (mode === 'prepend') {
-        input.value = '0';
+        input.value = '';
         return;
       }
       const counts = bases.map(b => utils.countWords(b));
+      if (mode === 'prepend') {
+        input.value = counts.map(() => 0).join(', ');
+        return;
+      }
       if (mode === 'append') {
         input.value = counts.join(', ');
         return;
       }
+      if (mode === 'random') {
+        const vals = counts.map(c => Math.floor(Math.random() * (c + 1)));
+        input.value = vals.join(', ');
+        return;
+      }
       input.value = '';
     };
-    select.addEventListener('change', () => {
+    const update = () => {
       const val = select.value;
       if (val === 'prepend' || val === 'append' || val === 'random') {
         build(val);
@@ -733,8 +759,27 @@
         input.value = lists.ORDER_PRESETS[val].join(', ');
       }
       if (rerollUpdaters[prefix]) rerollUpdaters[prefix].forEach(fn => fn());
+    };
+    select.addEventListener('change', update);
+    const ids = Array.isArray(watchIds) ? watchIds : [watchIds];
+    ids.forEach(id => {
+      const src = document.getElementById(id);
+      if (src) {
+        const handler = () => {
+          if (
+            select.value === 'prepend' ||
+            select.value === 'append' ||
+            select.value === 'random' ||
+            lists.ORDER_PRESETS[select.value]
+          ) {
+            update();
+          }
+        };
+        src.addEventListener('input', handler);
+        src.addEventListener('change', handler);
+      }
     });
-    select.dispatchEvent(new Event('change'));
+    update();
   }
 
   function updateDepthContainers(prefix, count) {
@@ -760,7 +805,7 @@
       ta.placeholder = '0,1,2';
       div.appendChild(ta);
       container.appendChild(div);
-      setupDepthControl(sel.id, ta.id);
+      setupDepthControl(sel.id, ta.id, ['base-input', 'base-select']);
     }
     for (let i = current; i > count; i--) {
       const idx = i;
@@ -900,8 +945,8 @@
       container.appendChild(block);
       setupPresetListener(sel.id, ta.id, type);
       applyPreset(sel, ta, type);
-      setupOrderControl(orderSel.id, oTa.id, () => utils.parseInput(ta.value));
-      setupDepthControl(depthSel.id, dTa.id);
+      setupOrderControl(orderSel.id, oTa.id, () => utils.parseInput(ta.value), ta.id);
+      setupDepthControl(depthSel.id, dTa.id, ['base-input', 'base-select']);
       setupRerollButton(rerollBtn.id, orderSel.id);
     }
     for (let i = current; i > count; i--) {
@@ -1058,12 +1103,15 @@
     fields.forEach(el => {
       if (el.tagName === 'SELECT') {
         el.selectedIndex = 0;
+        el.dispatchEvent(new Event('change'));
       } else if (el.type === 'checkbox') {
         el.checked = el.defaultChecked;
+        el.dispatchEvent(new Event('change'));
       } else {
         el.value = el.defaultValue || '';
+        el.dispatchEvent(new Event('input'));
+        el.dispatchEvent(new Event('change'));
       }
-      el.dispatchEvent(new Event('change'));
     });
     updateStackBlocks('pos', 1);
     updateStackBlocks('neg', 1);
@@ -1133,20 +1181,32 @@
     populateDepthOptions(document.getElementById('pos-depth-select'));
     populateDepthOptions(document.getElementById('neg-depth-select'));
 
-    setupOrderControl('base-order-select', 'base-order-input', () =>
-      utils.parseInput(document.getElementById('base-input').value, true)
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      ['base-input', 'base-select']
     );
-    setupOrderControl('pos-order-select', 'pos-order-input', () =>
-      utils.parseInput(document.getElementById('pos-input').value)
+    setupOrderControl(
+      'pos-order-select',
+      'pos-order-input',
+      () => utils.parseInput(document.getElementById('pos-input').value),
+      ['pos-input', 'pos-select']
     );
-    setupOrderControl('neg-order-select', 'neg-order-input', () =>
-      utils.parseInput(document.getElementById('neg-input').value)
+    setupOrderControl(
+      'neg-order-select',
+      'neg-order-input',
+      () => utils.parseInput(document.getElementById('neg-input').value),
+      ['neg-input', 'neg-select']
     );
-    setupOrderControl('divider-order-select', 'divider-order-input', () =>
-      utils.parseDividerInput(document.getElementById('divider-input').value || '')
+    setupOrderControl(
+      'divider-order-select',
+      'divider-order-input',
+      () => utils.parseDividerInput(document.getElementById('divider-input').value || ''),
+      ['divider-input', 'divider-select']
     );
-    setupDepthControl('pos-depth-select', 'pos-depth-input');
-    setupDepthControl('neg-depth-select', 'neg-depth-input');
+    setupDepthControl('pos-depth-select', 'pos-depth-input', ['base-input', 'base-select']);
+    setupDepthControl('neg-depth-select', 'neg-depth-input', ['base-input', 'base-select']);
     updateDepthContainers('pos', 1);
     updateDepthContainers('neg', 1);
     setupRerollButton('base-reroll', 'base-order-select');
@@ -1211,6 +1271,7 @@
     setupCopyButtons,
     setupDataButtons,
     setupOrderControl,
+    setupDepthControl,
     setupAdvancedToggle,
     updateStackBlocks,
     rerollRandomOrders,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -38,7 +38,9 @@ const {
   updateStackBlocks,
   setupSectionOrder,
   setupSectionHide,
-  setupSectionAdvanced
+  setupSectionAdvanced,
+  setupDepthControl,
+  setupPresetListener
 } = ui;
 
 describe('Utility functions', () => {
@@ -507,13 +509,16 @@ describe('UI interactions', () => {
       <button id="base-reroll" class="toggle-button random-button" data-select="base-order-select"></button>
     `;
     const orig = utils.shuffle;
-    utils.shuffle = jest.fn();
+    utils.shuffle = jest.fn(arr => {
+      arr.reverse();
+      return arr;
+    });
     setupOrderControl('base-order-select', 'base-order-input', () => ['a', 'b', 'c']);
     setupRerollButton('base-reroll', 'base-order-select');
     document.getElementById('base-reroll').click();
     expect(document.getElementById('base-order-select').value).toBe('random');
-    expect(document.getElementById('base-order-input').value).toBe('');
-    expect(utils.shuffle).not.toHaveBeenCalled();
+    expect(document.getElementById('base-order-input').value).toBe('2, 1, 0');
+    expect(utils.shuffle).toHaveBeenCalled();
     utils.shuffle = orig;
   });
 
@@ -537,6 +542,202 @@ describe('UI interactions', () => {
     rerollRandomOrders();
     utils.shuffle = orig;
     expect(document.getElementById('base-order-input').value).toBe('1, 0');
+  });
+
+  test('canonical base order updates when base input changes', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a</textarea>
+    `;
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'a,b,c';
+    baseInput.dispatchEvent(new Event('input'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
+  test('canonical base order updates on change events', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select">
+        <option value="canonical">c</option>
+      </select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a</textarea>
+    `;
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'a,b,c';
+    baseInput.dispatchEvent(new Event('change'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
+  test('random base order updates when base input changes', () => {
+    document.body.innerHTML = `
+      <select id="base-order-select">
+        <option value="canonical">c</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="base-input">a</textarea>
+    `;
+    const orig = utils.shuffle;
+    utils.shuffle = jest.fn(arr => {
+      arr.reverse();
+      return arr;
+    });
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const sel = document.getElementById('base-order-select');
+    sel.value = 'random';
+    sel.dispatchEvent(new Event('change'));
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'a,b,c';
+    baseInput.dispatchEvent(new Event('input'));
+    utils.shuffle = orig;
+    expect(document.getElementById('base-order-input').value).toBe('2, 1, 0');
+  });
+
+  test('append depth updates when base input changes', () => {
+    document.body.innerHTML = `
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="base-input">foo bar,baz</textarea>
+    `;
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const sel = document.getElementById('pos-depth-select');
+    sel.value = 'append';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('2, 1');
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'foo,baz qux quux';
+    baseInput.dispatchEvent(new Event('input'));
+    expect(document.getElementById('pos-depth-input').value).toBe('1, 3');
+  });
+
+  test('prepend depth populates zeros for each base term', () => {
+    document.body.innerHTML = `
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="base-input">foo bar,baz</textarea>
+    `;
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const sel = document.getElementById('pos-depth-select');
+    sel.value = 'prepend';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('0, 0');
+  });
+
+  test('depth populates when switching modes', () => {
+    document.body.innerHTML = `
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="append">a</option>
+        <option value="random">r</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="base-input">foo bar,baz</textarea>
+    `;
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const sel = document.getElementById('pos-depth-select');
+    sel.value = 'append';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('2, 1');
+    sel.value = 'random';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).not.toBe('');
+  });
+
+  test('append depth updates on change events', () => {
+    document.body.innerHTML = `
+      <select id="pos-depth-select">
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="base-input">foo bar,baz</textarea>
+    `;
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const sel = document.getElementById('pos-depth-select');
+    sel.value = 'append';
+    sel.dispatchEvent(new Event('change'));
+    const baseInput = document.getElementById('base-input');
+    baseInput.value = 'foo,baz qux quux';
+    baseInput.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('1, 3');
+  });
+
+  test('base order updates when selecting a preset', () => {
+    importLists({
+      presets: [
+        { id: 'b', title: 'b', type: 'base', items: ['a', 'b', 'c'] }
+      ]
+    });
+    document.body.innerHTML = `
+      <select id="base-select"><option value="b">b</option></select>
+      <textarea id="base-input"></textarea>
+      <select id="base-order-select"><option value="canonical">c</option></select>
+      <textarea id="base-order-input"></textarea>
+    `;
+    setupPresetListener('base-select', 'base-input', 'base');
+    setupOrderControl(
+      'base-order-select',
+      'base-order-input',
+      () => utils.parseInput(document.getElementById('base-input').value, true),
+      'base-input'
+    );
+    const sel = document.getElementById('base-select');
+    sel.value = 'b';
+    sel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('base-order-input').value).toBe('0, 1, 2');
+  });
+
+  test('depth updates when selecting a base preset', () => {
+    importLists({
+      presets: [
+        { id: 'b2', title: 'b2', type: 'base', items: ['foo bar', 'baz qux quux'] }
+      ]
+    });
+    document.body.innerHTML = `
+      <select id="base-select"><option value="b2">b2</option></select>
+      <textarea id="base-input"></textarea>
+      <select id="pos-depth-select">
+        <option value="prepend">p</option>
+        <option value="append">a</option>
+      </select>
+      <textarea id="pos-depth-input"></textarea>
+    `;
+    setupPresetListener('base-select', 'base-input', 'base');
+    setupDepthControl('pos-depth-select', 'pos-depth-input', 'base-input');
+    const depthSel = document.getElementById('pos-depth-select');
+    depthSel.value = 'append';
+    depthSel.dispatchEvent(new Event('change'));
+    const baseSel = document.getElementById('base-select');
+    baseSel.value = 'b2';
+    baseSel.dispatchEvent(new Event('change'));
+    expect(document.getElementById('pos-depth-input').value).toBe('2, 3');
   });
 
   test('rerollRandomOrders handles multiple order controls', () => {


### PR DESCRIPTION
## Summary
- watch both textarea and preset selects when syncing order and depth values
- ensure depth controls update when base preset changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687101f5e0e48321af9abd87e8ae4b31