### PR TITLE
Fix append depth when positive mods included

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -74,8 +74,6 @@
     for (let i = 0; i < len; i++) {
       let total = bases[i % bases.length];
       if (includePos) total += getTotalPosWords(i);
-      const mod = mods[i % (mods.length || 1)];
-      if (mod) total += utils.countWords(mod);
       counts.push(total);
     }
     return counts;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -653,7 +653,7 @@ describe('UI interactions', () => {
     const sel = document.getElementById('pos-depth-select');
     sel.value = 'append';
     sel.dispatchEvent(new Event('change'));
-    expect(document.getElementById('pos-depth-input').value).toBe('4');
+    expect(document.getElementById('pos-depth-input').value).toBe('2');
   });
 
   test('negative depth includes positive modifiers when enabled', () => {
@@ -680,7 +680,7 @@ describe('UI interactions', () => {
     const sel = document.getElementById('neg-depth-select');
     sel.value = 'append';
     sel.dispatchEvent(new Event('change'));
-    expect(document.getElementById('neg-depth-input').value).toBe('4');
+    expect(document.getElementById('neg-depth-input').value).toBe('3');
   });
 
   test('prepend depth populates zeros for each base term', () => {


### PR DESCRIPTION
## Summary
- correct depth count generation to ignore modifier lengths
- update tests for new depth logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872dec1eaa08321b8853e918a9e5630