### PR TITLE
Fix negative append depth when positives included

### DIFF
--- a/src/uiControls.js
+++ b/src/uiControls.js
@@ -75,7 +75,8 @@
       let total = bases[i % bases.length];
       if (includePos) total += getTotalPosWords(i);
       const mod = mods[i % (mods.length || 1)];
-      if (mod) total += utils.countWords(mod);
+      if (mod && !(prefix === 'neg' && includePos))
+        total += utils.countWords(mod);
       counts.push(total);
     }
     return counts;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -680,7 +680,7 @@ describe('UI interactions', () => {
     const sel = document.getElementById('neg-depth-select');
     sel.value = 'append';
     sel.dispatchEvent(new Event('change'));
-    expect(document.getElementById('neg-depth-input').value).toBe('4');
+    expect(document.getElementById('neg-depth-input').value).toBe('3');
   });
 
   test('prepend depth populates zeros for each base term', () => {


### PR DESCRIPTION
## Summary
- adjust `computeDepthCounts` so negative append depth doesn't include its own modifier length
- update expectations for negative depth computation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872dec1eaa08321b8853e918a9e5630