### PR TITLE
Improve depth watcher logic and tests

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -26,6 +26,13 @@ Directives for LLMs:
 
 Indentation is two spaces with no trailing whitespace.
 
+### Depth Control Note
+
+Depth inputs rely on DOM watchers to rebuild values when related fields change.
+Negative depth selectors that include positive modifiers must watch the
+corresponding positive fields. Update `updateDepthContainers` if new inputs are
+added so these watchers remain synchronized.
+
 ## Testing
 
 Run the full suite with `npm test` whenever you modify code. Expand coverage whenever a bug is fixed or a new feature is added.

--- a/src/script.js
+++ b/src/script.js
@@ -2206,7 +2206,16 @@
       const watchers = ['base-input', 'base-select'];
       watchers.push(`${prefix}-input${idx === 1 ? '' : '-' + idx}`);
       watchers.push(`${prefix}-order-input${idx === 1 ? '' : '-' + idx}`);
-      if (prefix === 'neg') watchers.push('neg-include-pos');
+      if (prefix === 'neg') {
+        watchers.push('neg-include-pos');
+        const count = document.getElementById('pos-stack')?.checked
+          ? parseInt(document.getElementById('pos-stack-size')?.value || '1', 10)
+          : 1;
+        for (let p = 1; p <= count; p++) {
+          watchers.push(`pos-input${p === 1 ? '' : '-' + p}`);
+          watchers.push(`pos-order-input${p === 1 ? '' : '-' + p}`);
+        }
+      }
       setupDepthControl(sel.id, ta.id, watchers);
     }
     for (let i = current; i > count; i--) {

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -5,6 +5,7 @@ This directory contains Jest test suites verifying functionality of the Prompt E
 - **Targeted Coverage**: For every new feature or bug fix, add a focused test that exercises the specific behavior. Reproduce previously observed issues so the bug cannot recur.
 - **Reusable Helpers**: Implement small utilities that load presets, generate prompts and save lists so that tests can chain these actions together. Helpers should keep DOM setup short and make it easy to compose common workflows.
 - **Randomized Sequential Tests**: In addition to deterministic unit tests, create tests that simulate a full user session. Randomly perform a sequence of actions—load, generate, modify, save—and assert that no errors are thrown and the generated output remains valid. Run these sequences multiple times to explore edge cases.
+- **Toggle Map**: For complex option interactions, maintain a table mapping toggle combinations to their expected output. Drive parameterized tests from this table so each scenario is explicitly verified.
 
 Remember the **50% Rule**: incremental test improvements build long-term reliability.
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -703,6 +703,82 @@ describe('UI interactions', () => {
     expect(document.getElementById('neg-depth-input').value).toBe('3');
   });
 
+  const appendMap = [
+    {
+      desc: 'negative append depth for second stack reacts to positive changes',
+      before: '3',
+      after: '4',
+      update() {
+        const inp = document.getElementById('pos-input-2');
+        inp.value = 'great job';
+        inp.dispatchEvent(new Event('input'));
+      }
+    }
+  ];
+
+  appendMap.forEach(cfg => {
+    test(cfg.desc, () => {
+      document.body.innerHTML = `
+        <input type="checkbox" id="pos-stack">
+        <select id="pos-stack-size"><option value="2">2</option></select>
+        <input type="checkbox" id="neg-stack">
+        <select id="neg-stack-size"><option value="2">2</option></select>
+        <input type="checkbox" id="neg-include-pos" checked>
+        <div id="neg-depth-container">
+          <select id="neg-depth-select"><option value="append">a</option></select>
+          <div class="input-row"><textarea id="neg-depth-input"></textarea></div>
+        </div>
+        <div id="pos-stack-container"></div>
+        <div id="neg-stack-container"></div>
+        <textarea id="pos-input"></textarea>
+        <textarea id="pos-order-input"></textarea>
+        <textarea id="pos-input-2">good</textarea>
+        <textarea id="pos-order-input-2"></textarea>
+        <textarea id="neg-input"></textarea>
+        <textarea id="neg-order-input"></textarea>
+        <textarea id="neg-input-2"></textarea>
+        <textarea id="neg-order-input-2"></textarea>
+        <textarea id="base-input">foo bar</textarea>
+        <select id="base-select"></select>
+      `;
+      setupDepthControl('neg-depth-select', 'neg-depth-input', [
+        'base-input',
+        'neg-input',
+        'neg-order-input',
+        'neg-include-pos',
+        'pos-input',
+        'pos-order-input'
+      ]);
+      document.getElementById('neg-stack-container').innerHTML =
+        '<div class="stack-block" id="neg-stack-1"></div>';
+      document.getElementById('pos-stack-container').innerHTML =
+        '<div class="stack-block" id="pos-stack-1"></div>';
+      const posStack = document.getElementById('pos-stack');
+      posStack.checked = true;
+      const negStack = document.getElementById('neg-stack');
+      negStack.checked = true;
+      updateStackBlocks('pos', 2);
+      updateStackBlocks('neg', 2);
+      setupDepthControl('neg-depth-select-2', 'neg-depth-input-2', [
+        'base-input',
+        'base-select',
+        'neg-input-2',
+        'neg-order-input-2',
+        'neg-include-pos',
+        'pos-input',
+        'pos-order-input',
+        'pos-input-2',
+        'pos-order-input-2'
+      ]);
+      const sel = document.getElementById('neg-depth-select-2');
+      sel.value = 'append';
+      sel.dispatchEvent(new Event('change'));
+      expect(document.getElementById('neg-depth-input-2').value).toBe(cfg.before);
+      cfg.update();
+      expect(document.getElementById('neg-depth-input-2').value).toBe(cfg.after);
+    });
+  });
+
   test('prepend depth populates zeros for each base term', () => {
     document.body.innerHTML = `
       <select id="pos-depth-select">


### PR DESCRIPTION
## Summary
- watch positive modifier inputs when computing negative depths
- document dependency on watchers in AGENTS files
- map append scenarios to expected depth values
- add test covering negative append depth edge case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738a06719c83218ddb70a08aee9935