### PR TITLE
Improve watcher documentation and export comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ npm test
 ```
 
 Tests live in the `tests/` directory and cover all functionality.
+
+The test suite runs under Node and therefore loads `script.js` via `require`. A small
+`module.exports` block at the bottom of the file exposes its helpers for these tests.
+Default preset data lives in `src/default_list.js` to keep the main script light.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -30,7 +30,8 @@ Indentation is two spaces with no trailing whitespace.
 
 Depth inputs rely on DOM watchers to rebuild values when related fields change.
 Negative depth selectors that include positive modifiers must watch the
-corresponding positive fields. Update `updateDepthContainers` if new inputs are
+corresponding positive fields. The helper `depthWatchIds` centralizes this list;
+update it or call `updateDepthContainers` with `refresh=true` when new inputs are
 added so these watchers remain synchronized.
 
 ## Testing

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -45,6 +45,8 @@ const {
   setupSectionHide,
   setupSectionAdvanced,
   setupDepthControl,
+  updateDepthContainers,
+  depthWatchIds,
   setupPresetListener
 } = ui;
 
@@ -923,6 +925,42 @@ describe('UI interactions', () => {
     const d2 = document.getElementById('pos-depth-input-2').value;
     expect(d1).not.toBe('');
     expect(d2).not.toBe('');
+  });
+
+  test('rerollRandomOrders refreshes negative append depth when stacks randomize', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input">foo bar</textarea>
+      <input type="checkbox" id="pos-stack" checked>
+      <select id="pos-stack-size"><option value="2">2</option></select>
+      <div id="pos-stack-container"></div>
+      <div id="pos-order-container"></div>
+      <select id="pos-order-select"><option value="canonical">c</option><option value="random">r</option></select>
+      <div class="input-row"><textarea id="pos-order-input"></textarea></div>
+      <select id="pos-order-select-2"><option value="canonical">c</option><option value="random">r</option></select>
+      <div class="input-row"><textarea id="pos-order-input-2"></textarea></div>
+      <textarea id="pos-input">good</textarea>
+      <textarea id="pos-input-2">great job</textarea>
+      <input type="checkbox" id="neg-stack" checked>
+      <select id="neg-stack-size"><option value="1">1</option></select>
+      <input type="checkbox" id="neg-include-pos" checked>
+      <div id="neg-depth-container">
+        <select id="neg-depth-select"><option value="append">a</option></select>
+        <div class="input-row"><textarea id="neg-depth-input"></textarea></div>
+      </div>`;
+    updateStackBlocks('pos', 2);
+    updateDepthContainers('neg', 1);
+    setupOrderControl('pos-order-select', 'pos-order-input', () => ['good', 'better']);
+    setupOrderControl('pos-order-select-2', 'pos-order-input-2', () => ['good', 'great job']);
+    setupDepthControl('neg-depth-select', 'neg-depth-input', depthWatchIds('neg', 1));
+    document.getElementById('pos-order-select').value = 'random';
+    document.getElementById('pos-order-select-2').value = 'random';
+    document.getElementById('neg-depth-select').value = 'append';
+    document.getElementById('neg-depth-select').dispatchEvent(new Event('change'));
+    const before = document.getElementById('neg-depth-input').value;
+    document.getElementById('neg-depth-input').value = '';
+    rerollRandomOrders();
+    const after = document.getElementById('neg-depth-input').value;
+    expect(after).toBe('5');
   });
 
   test('advanced toggle shows and hides controls', () => {


### PR DESCRIPTION
## Summary
- clarify that default preset data comes from `default_list.js`
- document CommonJS export block for Jest
- trigger watcher events when rerolling random orders
- export depth helpers
- note exports and data in README
- test rerolling with negative append depth and stacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738e5291fc83219205c1c0f34dfc95