### PR TITLE
Implement lyrics list insertion

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -30,9 +30,10 @@ Indentation is two spaces with no trailing whitespace.
 
 The lyrics section includes an optional list insertion tool. When active it
 inserts bracketed phrases into the lyrics at progressively larger depths. Each
-depth equals the prior depth plus a random amount between the user supplied
-min and max values. The depths are displayed for reference in a read‑only
-textarea.
+depth equals the prior depth plus a random amount between half of the chosen
+depth value and the value itself. Multiple insertion lists may be stacked just
+like positive or negative modifiers. The final depths are displayed for
+reference in a read‑only textarea.
 
 ### Depth Control Note
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -26,6 +26,14 @@ Directives for LLMs:
 
 Indentation is two spaces with no trailing whitespace.
 
+### Lyrics List Insertion
+
+The lyrics section includes an optional list insertion tool. When active it
+inserts bracketed phrases into the lyrics at progressively larger depths. Each
+depth equals the prior depth plus a random amount between the user supplied
+min and max values. The depths are displayed for reference in a read‑only
+textarea.
+
 ### Depth Control Note
 
 Depth inputs rely on DOM watchers to rebuild values when related fields change.

--- a/src/default_list.js
+++ b/src/default_list.js
@@ -689,6 +689,12 @@ const DEFAULT_LIST = {
       "type": "lyrics-insert"
     },
     {
+      "id": "lyrics-insert-emoji",
+      "title": "Emoji",
+      "items": ["🙂", "😊", "👍", "😃", "✨", "🎵"],
+      "type": "lyrics-insert"
+    },
+    {
       "id": "divider-simple",
       "title": "Simple",
       "items": [],

--- a/src/default_list.js
+++ b/src/default_list.js
@@ -683,6 +683,12 @@ const DEFAULT_LIST = {
       "type": "lyrics"
     },
     {
+      "id": "lyrics-insert-demo",
+      "title": "Demo Insert List",
+      "items": ["chorus", "verse"],
+      "type": "lyrics-insert"
+    },
+    {
       "id": "divider-simple",
       "title": "Simple",
       "items": [],

--- a/src/index.html
+++ b/src/index.html
@@ -270,6 +270,26 @@
           <option value="9">9</option>
           <option value="10">10</option>
         </select>
+        <div class="label-row">
+          <label for="lyrics-insert-input">List Insertion</label>
+          <input type="checkbox" id="lyrics-insert-toggle" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-insert-toggle" data-on="Insert On" data-off="Insert Off">Insert Off</button>
+        </div>
+        <select id="lyrics-insert-select"></select>
+        <div class="input-row">
+          <textarea id="lyrics-insert-input" rows="2" placeholder="phrases"></textarea>
+        </div>
+        <div class="label-row">
+          <label for="lyrics-insert-min">Min Depth</label>
+          <label for="lyrics-insert-max">Max Depth</label>
+        </div>
+        <div class="input-row">
+          <input type="number" id="lyrics-insert-min" value="1" min="1">
+          <input type="number" id="lyrics-insert-max" value="1" min="1">
+        </div>
+        <div class="input-row">
+          <textarea id="lyrics-insert-depth" rows="1" placeholder="depths" readonly></textarea>
+        </div>
       </div>
       <!-- Action buttons -->
         <button id="generate">Generate</button>

--- a/src/index.html
+++ b/src/index.html
@@ -274,18 +274,36 @@
           <label for="lyrics-insert-input">List Insertion</label>
           <input type="checkbox" id="lyrics-insert-toggle" hidden>
           <button type="button" class="toggle-button" data-target="lyrics-insert-toggle" data-on="Insert On" data-off="Insert Off">Insert Off</button>
+          <input type="checkbox" id="lyrics-insert-stack" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-insert-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
         </div>
-        <select id="lyrics-insert-select"></select>
-        <div class="input-row">
-          <textarea id="lyrics-insert-input" rows="2" placeholder="phrases"></textarea>
+        <select id="lyrics-insert-stack-size" style="display:none">
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+        </select>
+        <div id="lyrics-insert-stack-container">
+          <div class="stack-block section-lyrics" id="lyrics-insert-stack-1">
+            <div class="label-row">
+              <label>Stack 1</label>
+              <div class="button-col">
+                <button type="button" id="lyrics-insert-save-1" class="save-button icon-button" title="Save">&#128190;</button>
+                <button type="button" class="copy-button icon-button" data-target="lyrics-insert-input" title="Copy">&#128203;</button>
+                <input type="checkbox" id="lyrics-insert-hide-1" data-targets="lyrics-insert-input" hidden>
+                <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-insert-hide-1" data-on="☰" data-off="✖">☰</button>
+              </div>
+            </div>
+            <select id="lyrics-insert-select"></select>
+            <div class="input-row">
+              <textarea id="lyrics-insert-input" rows="2" placeholder="phrases"></textarea>
+            </div>
+          </div>
         </div>
         <div class="label-row">
-          <label for="lyrics-insert-min">Min Depth</label>
-          <label for="lyrics-insert-max">Max Depth</label>
+          <label for="lyrics-insert-depth-val">Depth</label>
         </div>
         <div class="input-row">
-          <input type="number" id="lyrics-insert-min" value="1" min="1">
-          <input type="number" id="lyrics-insert-max" value="1" min="1">
+          <input type="number" id="lyrics-insert-depth-val" value="2" min="1">
         </div>
         <div class="input-row">
           <textarea id="lyrics-insert-depth" rows="1" placeholder="depths" readonly></textarea>

--- a/src/script.js
+++ b/src/script.js
@@ -31,7 +31,7 @@
  *    - Event handlers and setup (setupPresetListener, initializeUI)
  *    - Reusable id iteration (forEachId)
  *    - Watcher utilities (depthWatchIds)
- *    - Lyrics extras (processLyrics list insertion)
+ *    - Lyrics extras (processLyrics list insertion, UI integration)
  * 6. Initialization and Exports
  *    - IIFE setup and module exports
  */
@@ -814,7 +814,7 @@
       length: { select: 'length-select', input: 'length-input', store: LENGTH_PRESETS },
       divider: { select: 'divider-select', input: 'divider-input', store: DIVIDER_PRESETS },
       lyrics: { select: 'lyrics-select', input: 'lyrics-input', store: LYRICS_PRESETS },
-      lyricsInsert: { select: 'lyrics-insert-select', input: 'lyrics-insert-input', store: LYRICS_INSERT_PRESETS },
+      'lyrics-insert': { select: 'lyrics-insert-select', input: 'lyrics-insert-input', store: LYRICS_INSERT_PRESETS },
       order: { select: 'pos-depth-select', input: 'pos-depth-input', store: ORDER_PRESETS }
     };
     const cfg = map[type];
@@ -1302,6 +1302,8 @@
         presets = lists.BASE_PRESETS;
       } else if (presetsOrType === 'lyrics') {
         presets = lists.LYRICS_PRESETS;
+      } else if (presetsOrType === 'lyrics-insert') {
+        presets = lists.LYRICS_INSERT_PRESETS;
       } else {
         presets = {};
       }
@@ -2652,6 +2654,11 @@
       document.getElementById('lyrics-input'),
       'lyrics'
     );
+    const liSel = document.getElementById('lyrics-insert-select');
+    const liInp = document.getElementById('lyrics-insert-input');
+    if (liSel && liInp) {
+      applyPreset(liSel, liInp, 'lyrics-insert');
+    }
   }
 
   /** 
@@ -2748,6 +2755,7 @@
     setupPresetListener('divider-select', 'divider-input', 'divider');
     setupPresetListener('base-select', 'base-input', 'base');
     setupPresetListener('lyrics-select', 'lyrics-input', 'lyrics');
+    setupPresetListener('lyrics-insert-select', 'lyrics-insert-input', 'lyrics-insert');
     populateOrderOptions(document.getElementById('base-order-select'));
     populateOrderOptions(document.getElementById('pos-order-select'));
     populateOrderOptions(document.getElementById('neg-order-select'));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1493,6 +1493,21 @@ describe('List persistence', () => {
     expect(opt).not.toBeNull();
   });
 
+  test('saveList works for lyrics insert', () => {
+    document.body.innerHTML = `
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input">foo</textarea>
+    `;
+    importLists({ presets: [] });
+    global.prompt = jest.fn().mockReturnValue('li1');
+    saveList('lyrics-insert');
+    const data = JSON.parse(exportLists());
+    const preset = data.presets.find(p => p.id === 'li1' && p.type === 'lyrics-insert');
+    expect(preset.items).toEqual(['foo']);
+    const opt = document.querySelector('#lyrics-insert-select option[value="li1"]');
+    expect(opt).not.toBeNull();
+  });
+
   test('sequential save and reload', () => {
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -1507,9 +1522,11 @@ describe('List persistence', () => {
       <textarea id="divider-input"></textarea>
       <select id="lyrics-select"></select>
       <textarea id="lyrics-input"></textarea>
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input"></textarea>
     `;
     importLists({ presets: [] });
-    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1', 'ly1'];
+    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1', 'ly1', 'li1'];
     global.prompt = jest.fn(() => names.shift());
     document.getElementById('pos-input').value = 'x';
     saveList('positive');
@@ -1525,9 +1542,11 @@ describe('List persistence', () => {
     saveList('divider');
     document.getElementById('lyrics-input').value = 'lyric';
     saveList('lyrics');
+    document.getElementById('lyrics-insert-input').value = 'foo';
+    saveList('lyrics-insert');
 
     const exported = JSON.parse(exportLists());
-    expect(exported.presets.length).toBe(7);
+    expect(exported.presets.length).toBe(8);
 
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -1542,6 +1561,8 @@ describe('List persistence', () => {
       <textarea id="divider-input"></textarea>
       <select id="lyrics-select"></select>
       <textarea id="lyrics-input"></textarea>
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input"></textarea>
     `;
     importLists(exported);
     const posSelVals = Array.from(document.querySelectorAll('#pos-select option')).map(o => o.value);
@@ -1572,6 +1593,11 @@ describe('List persistence', () => {
       lyrSelect.value = 'ly1';
       applyPreset(lyrSelect, lyrInput, 'lyrics');
       expect(lyrInput.value).toBe('lyric');
+      const insertSelect = document.getElementById('lyrics-insert-select');
+      const insertInput = document.getElementById('lyrics-insert-input');
+      insertSelect.value = 'li1';
+      applyPreset(insertSelect, insertInput, 'lyrics-insert');
+      expect(insertInput.value).toBe('foo');
   });
 
   test('importLists additive merges lists', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -448,6 +448,25 @@ describe('Lyrics processing', () => {
     const out = processLyrics(input, 1, false, true);
     expect(out).toBe('alpha gamma');
   });
+
+  test('processLyrics inserts list items and reports depths', () => {
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0);
+    const depths = [];
+    const out = processLyrics(
+      'a b c',
+      1,
+      false,
+      false,
+      ['x', 'y'],
+      1,
+      1,
+      d => depths.push(...d)
+    );
+    Math.random = orig;
+    expect(out).toBe('a [x] b [y] c');
+    expect(depths).toEqual([1, 3]);
+  });
 });
 
 describe('UI interactions', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -41,6 +41,7 @@ const {
   rerollRandomOrders,
   setupAdvancedToggle,
   updateStackBlocks,
+  updateInsertStackBlocks,
   setupSectionOrder,
   setupSectionHide,
   setupSectionAdvanced,
@@ -459,8 +460,7 @@ describe('Lyrics processing', () => {
       false,
       false,
       ['x', 'y'],
-      1,
-      1,
+      2,
       d => depths.push(...d)
     );
     Math.random = orig;
@@ -1650,6 +1650,18 @@ describe('List persistence', () => {
     updateStackBlocks('pos', 2);
     const block = document.getElementById('pos-stack-2');
     expect(block.querySelector('.copy-button')).not.toBeNull();
+    expect(block.querySelector('.save-button')).not.toBeNull();
+  });
+
+  test('updateInsertStackBlocks creates stack blocks', () => {
+    document.body.innerHTML = `
+      <select id="lyrics-insert-select"></select>
+      <div id="lyrics-insert-stack-container">
+        <div class="stack-block" id="lyrics-insert-stack-1"></div>
+      </div>`;
+    updateInsertStackBlocks(2);
+    const block = document.getElementById('lyrics-insert-stack-2');
+    expect(block).not.toBeNull();
     expect(block.querySelector('.save-button')).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- add `lyrics-insert-demo` preset
- allow random list insertion in `processLyrics`
- expose lyrics insertion presets and controls
- add list insertion UI fields
- document the feature in AGENTS guidelines
- test new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874aec9a80483218319010c145d9f4e