### PR TITLE
Implement lyrics list insertion

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -26,6 +26,15 @@ Directives for LLMs:
 
 Indentation is two spaces with no trailing whitespace.
 
+### Lyrics List Insertion
+
+The lyrics section includes an optional list insertion tool. When active it
+inserts bracketed phrases into the lyrics at progressively larger depths. Each
+depth equals the prior depth plus a random amount. The user specifies a single
+interval value. Half of that interval is used as the minimal step and the full
+value is the maximum. Calculated depths appear in a read‑only textarea for
+reference.
+
 ### Depth Control Note
 
 Depth inputs rely on DOM watchers to rebuild values when related fields change.

--- a/src/default_list.js
+++ b/src/default_list.js
@@ -683,6 +683,18 @@ const DEFAULT_LIST = {
       "type": "lyrics"
     },
     {
+      "id": "lyrics-insert-demo",
+      "title": "Demo Insert List",
+      "items": ["chorus", "verse"],
+      "type": "lyrics-insert"
+    },
+    {
+      "id": "emoji-positive",
+      "title": "Positive Emojis",
+      "items": ["👍", "😊", "😀", "😁", "🥳"],
+      "type": "lyrics-insert"
+    },
+    {
       "id": "divider-simple",
       "title": "Simple",
       "items": [],

--- a/src/index.html
+++ b/src/index.html
@@ -270,6 +270,42 @@
           <option value="9">9</option>
           <option value="10">10</option>
         </select>
+        <div class="label-row">
+          <label for="lyrics-insert-input">List Insertion</label>
+          <input type="checkbox" id="lyrics-insert-toggle" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-insert-toggle" data-on="Insert On" data-off="Insert Off">Insert Off</button>
+          <input type="checkbox" id="lyrics-insert-stack" hidden>
+          <button type="button" class="toggle-button" data-target="lyrics-insert-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
+        </div>
+        <select id="lyrics-insert-stack-size" style="display:none">
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+        </select>
+        <div id="lyrics-insert-stack-container">
+          <div class="stack-block section-lyrics" id="lyrics-insert-stack-1">
+            <div class="label-row">
+              <label>Stack 1</label>
+              <div class="button-col">
+                <button type="button" id="lyrics-insert-save-1" class="save-button icon-button" title="Save">&#128190;</button>
+                <button type="button" class="copy-button icon-button" data-target="lyrics-insert-input" title="Copy">&#128203;</button>
+                <input type="checkbox" id="lyrics-insert-hide-1" data-targets="lyrics-insert-input" hidden>
+                <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-insert-hide-1" data-on="☰" data-off="✖">☰</button>
+              </div>
+            </div>
+            <select id="lyrics-insert-select"></select>
+            <div class="input-row">
+              <textarea id="lyrics-insert-input" rows="2" placeholder="phrases"></textarea>
+            </div>
+          </div>
+        </div>
+        <div class="label-row">
+          <label for="lyrics-insert-distance">Depth Interval</label>
+        </div>
+        <input type="number" id="lyrics-insert-distance" value="4" min="1">
+        <div class="input-row">
+          <textarea id="lyrics-insert-depth" rows="1" placeholder="depths" readonly></textarea>
+        </div>
       </div>
       <!-- Action buttons -->
         <button id="generate">Generate</button>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -448,6 +448,24 @@ describe('Lyrics processing', () => {
     const out = processLyrics(input, 1, false, true);
     expect(out).toBe('alpha gamma');
   });
+
+  test('processLyrics inserts list items and reports depths', () => {
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0);
+    const depths = [];
+    const out = processLyrics(
+      'a b c',
+      1,
+      false,
+      false,
+      ['x', 'y'],
+      2,
+      d => depths.push(...d)
+    );
+    Math.random = orig;
+    expect(out).toBe('a [x] b [y] c');
+    expect(depths).toEqual([1, 3]);
+  });
 });
 
 describe('UI interactions', () => {
@@ -1474,6 +1492,21 @@ describe('List persistence', () => {
     expect(opt).not.toBeNull();
   });
 
+  test('saveList works for lyrics insert', () => {
+    document.body.innerHTML = `
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input">foo</textarea>
+    `;
+    importLists({ presets: [] });
+    global.prompt = jest.fn().mockReturnValue('li1');
+    saveList('lyrics-insert');
+    const data = JSON.parse(exportLists());
+    const preset = data.presets.find(p => p.id === 'li1' && p.type === 'lyrics-insert');
+    expect(preset.items).toEqual(['foo']);
+    const opt = document.querySelector('#lyrics-insert-select option[value="li1"]');
+    expect(opt).not.toBeNull();
+  });
+
   test('sequential save and reload', () => {
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -1488,9 +1521,11 @@ describe('List persistence', () => {
       <textarea id="divider-input"></textarea>
       <select id="lyrics-select"></select>
       <textarea id="lyrics-input"></textarea>
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input"></textarea>
     `;
     importLists({ presets: [] });
-    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1', 'ly1'];
+    let names = ['p1', 'p2', 'b1', 'n1', 'l1', 'd1', 'ly1', 'li1'];
     global.prompt = jest.fn(() => names.shift());
     document.getElementById('pos-input').value = 'x';
     saveList('positive');
@@ -1506,9 +1541,11 @@ describe('List persistence', () => {
     saveList('divider');
     document.getElementById('lyrics-input').value = 'lyric';
     saveList('lyrics');
+    document.getElementById('lyrics-insert-input').value = 'foo';
+    saveList('lyrics-insert');
 
     const exported = JSON.parse(exportLists());
-    expect(exported.presets.length).toBe(7);
+    expect(exported.presets.length).toBe(8);
 
     document.body.innerHTML = `
       <select id="pos-select"></select>
@@ -1523,6 +1560,8 @@ describe('List persistence', () => {
       <textarea id="divider-input"></textarea>
       <select id="lyrics-select"></select>
       <textarea id="lyrics-input"></textarea>
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input"></textarea>
     `;
     importLists(exported);
     const posSelVals = Array.from(document.querySelectorAll('#pos-select option')).map(o => o.value);
@@ -1553,6 +1592,11 @@ describe('List persistence', () => {
       lyrSelect.value = 'ly1';
       applyPreset(lyrSelect, lyrInput, 'lyrics');
       expect(lyrInput.value).toBe('lyric');
+      const insertSelect = document.getElementById('lyrics-insert-select');
+      const insertInput = document.getElementById('lyrics-insert-input');
+      insertSelect.value = 'li1';
+      applyPreset(insertSelect, insertInput, 'lyrics-insert');
+      expect(insertInput.value).toBe('foo');
   });
 
   test('importLists additive merges lists', () => {


### PR DESCRIPTION
## Summary
- add default positive emoji insertion list
- allow stacking for lyrics insertion lists
- simplify insertion depth to single interval
- update algorithm to use half-interval minimum
- document lyrics insertions
- test updated processLyrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874aec9a80483218319010c145d9f4e