### PR TITLE
Fix depth counts for stacked modifiers

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -34,6 +34,10 @@ corresponding positive fields. The helper `depthWatchIds` centralizes this list;
 update it or call `updateDepthContainers` with `refresh=true` when new inputs are
 added so these watchers remain synchronized.
 
+`computeDepthCounts` now sums words from earlier stacks for both positive and
+negative sections. Random depth calculations therefore consider all preceding
+modifiers when multiple stacks are active.
+
 ## Testing
 
 Run the full suite with `npm test` whenever you modify code. Expand coverage whenever a bug is fixed or a new feature is added.

--- a/src/script.js
+++ b/src/script.js
@@ -1217,6 +1217,32 @@
   }
 
   /**
+   * Words from earlier stacks of a section.
+   * Purpose: Calculate prior stack impact on later depths.
+   * Usage: In computeDepthCounts.
+   * 50% Rule: Iterates over existing stacks with comments.
+   * @param {string} prefix - Section prefix.
+   * @param {number} idx - Current stack index.
+   * @param {number} i - Item index.
+   * @returns {number} - Word count total.
+   */
+  function getPrevStackWords(prefix, idx, i) {
+    const stackOn = document.getElementById(`${prefix}-stack`)?.checked;
+    const stackSize = parseInt(
+      document.getElementById(`${prefix}-stack-size`)?.value || '1',
+      10
+    );
+    const count = stackOn ? stackSize : 1;
+    let total = 0;
+    for (let s = 1; s < idx && s <= count; s++) {
+      const mods = getOrderedMods(prefix, s);
+      if (!mods.length) continue;
+      total += utils.countWords(mods[i % mods.length]);
+    }
+    return total;
+  }
+
+  /**
    * Determine insertion depths for modifiers so negative depth calculations
    * know where the base phrase ends.
    * Purpose: Compute word counts for depth insertions.
@@ -1238,6 +1264,7 @@
     for (let i = 0; i < len; i++) {
       let total = bases[i % bases.length];
       if (includePos) total += getTotalPosWords(i);
+      total += getPrevStackWords(prefix, idx, i);
       counts.push(total);
     }
     return counts;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -24,7 +24,8 @@ const {
   parseOrderInput,
   applyOrder,
   insertAtDepth,
-  countWords
+  countWords,
+  computeDepthCounts
 } = utils;
 
 const { exportLists, importLists, saveList } = lists;
@@ -218,6 +219,39 @@ describe('Prompt building', () => {
       [0]
     );
     expect(out).toEqual({ positive: 'pre foo bar post, pre foo bar post', negative: 'n foo bar, n foo bar' });
+  });
+
+  test('computeDepthCounts includes prior positive stacks', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input">foo bar</textarea>
+      <textarea id="pos-input">p1</textarea>
+      <textarea id="pos-input-2">p2</textarea>
+      <textarea id="pos-order-input"></textarea>
+      <textarea id="pos-order-input-2"></textarea>
+      <input id="pos-stack" type="checkbox" checked>
+      <input id="pos-stack-size" value="2">
+    `;
+    const counts = computeDepthCounts('pos', 2);
+    expect(counts).toEqual([3]);
+  });
+
+  test('computeDepthCounts includes prior negative stacks and positives', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input">foo bar</textarea>
+      <textarea id="pos-input">good</textarea>
+      <textarea id="pos-order-input"></textarea>
+      <input id="pos-stack" type="checkbox" checked>
+      <input id="pos-stack-size" value="1">
+      <textarea id="neg-input">bad1</textarea>
+      <textarea id="neg-input-2">bad2</textarea>
+      <textarea id="neg-order-input"></textarea>
+      <textarea id="neg-order-input-2"></textarea>
+      <input id="neg-stack" type="checkbox" checked>
+      <input id="neg-stack-size" value="2">
+      <input id="neg-include-pos" type="checkbox" checked>
+    `;
+    const counts = computeDepthCounts('neg', 2);
+    expect(counts).toEqual([4]);
   });
 
   test('buildVersions returns empty strings when items list is empty', () => {


### PR DESCRIPTION
## Summary
- count words from prior stacks in `computeDepthCounts`
- document new depth logic
- test `computeDepthCounts` for positive and negative stacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875896358988321a93c6c719787d85b