### PR TITLE
feat: add lyric insertions list

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -38,6 +38,13 @@ added so these watchers remain synchronized.
 negative sections. Random depth calculations therefore consider all preceding
 modifiers when multiple stacks are active.
 
+### Lyrics Insertions
+
+Lyrics processing includes an optional *Insertions* list. Terms from this list
+are injected at word intervals and can stack multiple items inside brackets.
+When adding new controls to this subsystem, ensure related selectors are
+included in presets and state persistence.
+
 ## Testing
 
 Run the full suite with `npm test` whenever you modify code. Expand coverage whenever a bug is fixed or a new feature is added.

--- a/src/default_list.js
+++ b/src/default_list.js
@@ -683,6 +683,12 @@ const DEFAULT_LIST = {
       "type": "lyrics"
     },
     {
+      "id": "insert-sample",
+      "title": "Empty Insertions",
+      "items": [],
+      "type": "insertion"
+    },
+    {
       "id": "divider-simple",
       "title": "Simple",
       "items": [],

--- a/src/index.html
+++ b/src/index.html
@@ -251,25 +251,69 @@
             <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="☰" data-off="✖">☰</button>
           </div>
         </div>
-        <select id="lyrics-select"></select>
-        <div class="input-row">
-          <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
+        <div id="lyrics-container">
+          <div class="stack-block section-lyrics" id="lyrics-block">
+            <select id="lyrics-select"></select>
+            <div class="input-row">
+              <textarea id="lyrics-input" rows="4" placeholder="Enter lyrics"></textarea>
+            </div>
+            <div class="label-row">
+              <label for="lyrics-space">Max Spaces</label>
+            </div>
+            <select id="lyrics-space">
+              <option value="1">1</option>
+              <option value="2" selected>2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+              <option value="6">6</option>
+              <option value="7">7</option>
+              <option value="8">8</option>
+              <option value="9">9</option>
+              <option value="10">10</option>
+            </select>
+          </div>
+          <div class="stack-block section-lyrics" id="lyrics-insert-block">
+            <div class="label-row">
+              <label for="lyrics-insert-input">Insertions</label>
+              <div class="button-col">
+                <button type="button" id="lyrics-insert-save" class="save-button icon-button" title="Save">&#128190;</button>
+                <button type="button" class="copy-button icon-button" data-target="lyrics-insert-input" title="Copy">&#128203;</button>
+                <input type="checkbox" id="lyrics-insert-hide" data-targets="lyrics-insert-input,lyrics-insert-interval,lyrics-insert-stack" hidden>
+                <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-insert-hide" data-on="☰" data-off="✖">☰</button>
+              </div>
+            </div>
+            <select id="lyrics-insert-select"></select>
+            <div class="input-row">
+              <textarea id="lyrics-insert-input" rows="2" placeholder="Insert terms"></textarea>
+            </div>
+            <div class="label-row">
+              <label for="lyrics-insert-interval">Insert Every</label>
+            </div>
+            <select id="lyrics-insert-interval">
+              <option value="0" selected>0</option>
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+              <option value="5">5</option>
+              <option value="6">6</option>
+              <option value="7">7</option>
+              <option value="8">8</option>
+              <option value="9">9</option>
+              <option value="10">10</option>
+            </select>
+            <div class="label-row">
+              <label for="lyrics-insert-stack">Stack Size</label>
+            </div>
+            <select id="lyrics-insert-stack">
+              <option value="1" selected>1</option>
+              <option value="2">2</option>
+              <option value="3">3</option>
+              <option value="4">4</option>
+            </select>
+          </div>
         </div>
-        <div class="label-row">
-          <label for="lyrics-space">Max Spaces</label>
-        </div>
-        <select id="lyrics-space">
-          <option value="1">1</option>
-          <option value="2" selected>2</option>
-          <option value="3">3</option>
-          <option value="4">4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-          <option value="10">10</option>
-        </select>
       </div>
       <!-- Action buttons -->
         <button id="generate">Generate</button>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -517,6 +517,19 @@ describe('Lyrics processing', () => {
     const out = processLyrics(input, 1, false, true);
     expect(out).toBe('alpha gamma');
   });
+
+  test('processLyrics inserts terms at intervals', () => {
+    const out = processLyrics('a b c d', 1, false, false, ['x'], 2, 1);
+    expect(out).toBe('a b [x] c d');
+  });
+
+  test('processLyrics stacks multiple insertions', () => {
+    const orig = Math.random;
+    Math.random = jest.fn().mockReturnValue(0);
+    const out = processLyrics('a b c d', 1, false, false, ['x','y'], 2, 2);
+    Math.random = orig;
+    expect(out).toBe('a b [y x] c d');
+  });
 });
 
 describe('UI interactions', () => {
@@ -1540,6 +1553,21 @@ describe('List persistence', () => {
     const preset = data.presets.find(p => p.id === 'ly1' && p.type === 'lyrics');
     expect(preset.items).toEqual(['line1\nline2']);
     const opt = document.querySelector('#lyrics-select option[value="ly1"]');
+    expect(opt).not.toBeNull();
+  });
+
+  test('saveList works for insertions', () => {
+    document.body.innerHTML = `
+      <select id="lyrics-insert-select"></select>
+      <textarea id="lyrics-insert-input">a,b</textarea>
+    `;
+    importLists({ presets: [] });
+    global.prompt = jest.fn().mockReturnValue('ins1');
+    saveList('insertion');
+    const data = JSON.parse(exportLists());
+    const preset = data.presets.find(p => p.id === 'ins1' && p.type === 'insertion');
+    expect(preset.items).toEqual(['a', 'b']);
+    const opt = document.querySelector('#lyrics-insert-select option[value="ins1"]');
     expect(opt).not.toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- add Insertions list to Lyrics section with interval and stack size selectors
- support insertion presets and processing logic
- test and document insertions feature

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d50bc32883218184dc88ae055be4