### PR TITLE
Fix default list initialization and reset

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1030,7 +1030,8 @@
 // Section Purpose: Persist data to localStorage.
 // Combines error handling and fallbacks to apply 50% Rule for robust storage.
 // Structural Overview: Uses KEY for storage; handles JSON.
-// Section Summary: Manages persistence for lists and state.
+// Section Summary: Manages persistence for lists and state, with reset
+// falling back to built-in defaults.
 
   const KEY = 'promptEnhancerData';
 
@@ -1137,11 +1138,11 @@
     }
   }
 
-  /** 
+  /**
    * Clear localStorage and reload defaults.
    * Purpose: Reset data.
    * Usage: On reset button.
-   * 50% Rule: Remove and import default.
+   * 50% Rule: Remove and import default or fallback lists.
    */
   function resetData() {
     if (typeof localStorage !== 'undefined') {
@@ -1153,6 +1154,9 @@
     }
     if (typeof DEFAULT_DATA !== 'undefined') {
       importData(DEFAULT_DATA);
+    } else if (typeof DEFAULT_LIST !== 'undefined') {
+      // Fallback when no full state is provided
+      lists.importLists(DEFAULT_LIST);
     }
   }
 
@@ -1162,7 +1166,8 @@
 // Section Purpose: Handle user interface interactions and event setups.
 // Layers multiple setup functions and event listeners for comprehensive UI control.
 // Structural Overview: Many setup functions for buttons, toggles, etc.
-// Section Summary: Manages all DOM interactions and event binding.
+// Section Summary: Manages all DOM interactions and event binding, ensuring
+// dropdowns are populated on startup.
 
   /** 
    * Infer the section prefix from a control id.
@@ -2792,14 +2797,15 @@
     }
   }
 
-  /** 
+  /**
    * Startup routine called once DOM is ready.
-   * Purpose: Initialize everything.
+   * Purpose: Initialize everything and load preset dropdowns.
    * Usage: On load.
    * 50% Rule: Calls all setups.
    */
   function initializeUI() {
     storage.loadPersisted();
+    loadLists(); // Populate selects on first load
     applyCurrentPresets();
 
     setupPresetListener('neg-select', 'neg-input', 'negative');

--- a/tests/defaultList.test.js
+++ b/tests/defaultList.test.js
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+
+global.__TEST__ = true;
+if (typeof window !== 'undefined') window.__TEST__ = true;
+
+// Define default lists before loading script
+global.DEFAULT_LIST = {
+  presets: [{ id: 'b', title: 'Base', type: 'base', items: ['x'] }]
+};
+
+delete global.DEFAULT_DATA;
+
+const main = require('../src/script');
+
+const ui = main;
+const lists = main;
+const storage = main;
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <select id="neg-select"></select>
+    <textarea id="neg-input"></textarea>
+    <select id="pos-select"></select>
+    <textarea id="pos-input"></textarea>
+    <select id="length-select"></select>
+    <input id="length-input">
+    <select id="divider-select"></select>
+    <textarea id="divider-input"></textarea>
+    <select id="base-select"></select>
+    <textarea id="base-input"></textarea>
+    <select id="lyrics-select"></select>
+    <textarea id="lyrics-input"></textarea>
+    <select id="lyrics-insert-select"></select>
+    <textarea id="lyrics-insert-input"></textarea>
+  `;
+}
+
+describe('Default list integration', () => {
+  test('loadLists populates default presets', () => {
+    setupDOM();
+    expect(document.querySelectorAll('#base-select option').length).toBe(0);
+    main.loadLists();
+    main.applyCurrentPresets();
+    const opts = Array.from(document.querySelectorAll('#base-select option')).map(o => o.value);
+    expect(opts).toEqual(['b']);
+    expect(document.getElementById('base-input').value).toBe('x');
+  });
+
+  test('resetData falls back to DEFAULT_LIST', () => {
+    setupDOM();
+    lists.importLists({ presets: [{ id: 'c', title: 'Custom', type: 'base', items: ['y'] }] });
+    main.applyCurrentPresets();
+    expect(document.getElementById('base-input').value).toBe('y');
+    storage.resetData();
+    main.applyCurrentPresets();
+    const opts = Array.from(document.querySelectorAll('#base-select option')).map(o => o.value);
+    expect(opts).toEqual(['b']);
+    expect(document.getElementById('base-input').value).toBe('x');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure dropdowns populate with built-in presets on startup
- reset button now restores default lists when no saved data
- cover default list loading and reset behavior with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e0b8403483219140b2534c5a2494