### PR TITLE
Preserve apostrophes in lyrics processor

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -514,17 +514,19 @@
   }
 
   /**
-   * Normalize a block of lyrics text.
-   * All punctuation is stripped, optionally removing parentheses or brackets,
-   * and random spacing up to `maxSpaces` is introduced between words. Unicode
-   * letters from any language are preserved. Optional insertions wrapped in
+  * Normalize a block of lyrics text.
+  * Most punctuation is stripped while internal apostrophes remain so
+  * contractions keep their pronunciation. Parentheses or brackets can be
+  * optionally removed, and random spacing up to `maxSpaces` is introduced
+  * between words. Unicode letters from any language are preserved. Optional
+  * insertions wrapped in
    * brackets can be injected every `interval` words, stacking multiple items
    * per insertion. When `randomize` is true the interval becomes the average
    * spacing and injection points are chosen uniformly across the lyrics.
    * Purpose: Process lyrics for use in prompts, adding randomness and optional
    * bracketed insertions with optional random placement.
-   * Usage Example: processLyrics("hello world", 2, false, false, ['x'], 2, 1, true)
-   *   may yield "hello [x] world".
+  * Usage Example: processLyrics("hello world", 2, false, false, ['x'], 2, 1, true)
+  *   may yield "hello [x] world". processLyrics("We'd", 1) returns "we'd".
    * 50% Rule: Regex cleaning, token insertion, and random spacing; comments,
    * example, and summary reinforce intent.
    * @param {string} text - Input lyrics.
@@ -554,7 +556,9 @@
     if (removeParens) cleaned = cleaned.replace(/\([^()]*\)/g, ' ');
     if (removeBrackets) cleaned = cleaned.replace(/\[[^\]]*\]|\{[^}]*\}|<[^>]*>/g, ' ');
     // Use Unicode property escapes so non-English letters remain intact
+    // Allow straight (') and curly (\u2019) apostrophes to preserve contractions
     let pattern = '[^\\p{L}\\p{N}\\s';
+    pattern += "'\u2019";
     if (!removeParens) pattern += '\\(\\)';
     if (!removeBrackets) pattern += '\\[\\]\\{\\}<>';
     pattern += ']';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -490,6 +490,12 @@ describe('Lyrics processing', () => {
     expect(out).toBe('שלום 你好 world');
   });
 
+  test('processLyrics retains apostrophes in contractions', () => {
+    const input = "We'd we're we’re can't";
+    const out = processLyrics(input, 1);
+    expect(out).toBe("we'd we're we’re can't");
+  });
+
   test('processLyrics inserts random spaces up to max', () => {
     const orig = Math.random;
     Math.random = jest.fn().mockReturnValue(0.9);
@@ -706,11 +712,8 @@ describe('UI interactions', () => {
       <textarea id="base-order-input"></textarea>
       <textarea id="base-input">a</textarea>
     `;
-    const orig = utils.shuffle;
-    utils.shuffle = jest.fn(arr => {
-      arr.reverse();
-      return arr;
-    });
+    const origRand = Math.random;
+    Math.random = jest.fn().mockReturnValue(0);
     setupOrderControl(
       'base-order-select',
       'base-order-input',
@@ -723,8 +726,8 @@ describe('UI interactions', () => {
     const baseInput = document.getElementById('base-input');
     baseInput.value = 'a,b,c';
     baseInput.dispatchEvent(new Event('input'));
-    utils.shuffle = orig;
-    expect(document.getElementById('base-order-input').value).not.toBe('0, 1, 2');
+    Math.random = origRand;
+    expect(document.getElementById('base-order-input').value).toBe('1, 2, 0');
   });
 
   test('append depth updates when base input changes', () => {


### PR DESCRIPTION
## Summary
- Keep straight and curly apostrophes when normalizing lyrics so contractions retain pronunciation.
- Add regression test for apostrophes and stabilize random base-order test using deterministic `Math.random`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bae2337c832183e4d6352c0b26f0