### PR TITLE
Add interactive help mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENT Instructions for Prompt-Enhancer
 
 This project is a lightweight web tool written in vanilla JavaScript. Indentation is two spaces with no trailing whitespace.
-All client logic lives in a single `script.js` file to make code search easy when collaborating with an LLM. Keep that file well commented and organized as described in `src/AGENTS.md`.
+All client logic lives in a single `script.js` file to make code search easy when collaborating with an LLM. Keep that file well commented and organized as described in `src/AGENTS.md`. Help Mode uses `data-help` attributes or a central map in `script.js` to surface tooltips; maintain those hints when adding or changing controls.
 
 The project embraces the **50% Rule**: many small, better-than-even improvements compound into reliable software. Document intent and reasoning so later revisions build on that advantage.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENT Instructions for Prompt-Enhancer
 
 This project is a lightweight web tool written in vanilla JavaScript. Indentation is two spaces with no trailing whitespace.
-All client logic lives in a single `script.js` file to make code search easy when collaborating with an LLM. Keep that file well commented and organized as described in `src/AGENTS.md`. Help Mode uses `data-help` attributes or a central map in `script.js` to surface tooltips; maintain those hints when adding or changing controls.
+All client logic lives in a single `script.js` file to make code search easy when collaborating with an LLM. Keep that file well commented and organized as described in `src/AGENTS.md`. Help Mode uses `data-help` attributes or a central map in `script.js` to surface tooltips; maintain those hints when adding or changing controls. Provide clear, specific `data-help` text for every button, list, and input field—avoid generic phrases.
 
 The project embraces the **50% Rule**: many small, better-than-even improvements compound into reliable software. Document intent and reasoning so later revisions build on that advantage.
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -47,6 +47,12 @@ positions selected uniformly across the lyrics. When adding new controls to
 this subsystem, ensure related selectors are included in presets and state
 persistence.
 
+### Help Mode
+
+Help Mode uses `data-help` attributes or the `helpMap` in `script.js` to show
+tooltips when users click elements. When new buttons or sections are added,
+provide a concise description so the help overlay stays informative.
+
 ## Testing
 
 Run the full suite with `npm test` whenever you modify code. Expand coverage whenever a bug is fixed or a new feature is added.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -50,8 +50,9 @@ persistence.
 ### Help Mode
 
 Help Mode uses `data-help` attributes or the `helpMap` in `script.js` to show
-tooltips when users click elements. When new buttons or sections are added,
-provide a concise description so the help overlay stays informative.
+tooltips when users click elements. Lists and input boxes also need coverage;
+avoid vague text. When new buttons or sections are added, provide concise,
+specific descriptions so the help overlay stays informative.
 
 ## Testing
 

--- a/src/index.html
+++ b/src/index.html
@@ -51,6 +51,9 @@
             <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
             <input type="checkbox" id="advanced-mode" hidden>
             <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
+            <!-- Help mode toggles tooltip explanations for UI elements -->
+            <input type="checkbox" id="help-mode" hidden>
+            <button type="button" class="toggle-button" data-target="help-mode" data-on="Help On" data-off="Help Off">Help Off</button>
           </div>
         </div>
         <!-- Base prompt input section -->

--- a/src/script.js
+++ b/src/script.js
@@ -2806,7 +2806,7 @@
    * Enable help mode with clickable tooltips.
    * Purpose: Explain UI elements via data-help attributes.
    * Usage: Called in initializeUI.
-   * 50% Rule: Maps help text, intercepts clicks, displays tooltip.
+   * 50% Rule: Maps help text, applies it to new and existing controls, then intercepts clicks and displays a tooltip.
    */
   function setupHelpMode() {
     const cb = document.getElementById('help-mode');
@@ -2829,14 +2829,74 @@
       '.section-negative': 'Negative modifiers or outputs.',
       '.section-divider': 'Connector phrases placed between terms.',
       '.section-length': 'Character limit controls.',
-      '.section-lyrics': 'Lyrics entry and processing.'
+      '.section-lyrics': 'Lyrics entry and processing.',
+      // Toggle buttons
+      '[data-target="pos-stack"]': 'Combine multiple positive lists.',
+      '[data-target="pos-all-hide"]': 'Show or hide all positive stacks.',
+      '[data-target="pos-order-random"]': 'Randomize order of positive modifiers.',
+      '[data-target="pos-advanced"]': 'Reveal advanced positive options.',
+      '[data-target="neg-include-pos"]': 'Apply negatives after positive prompt.',
+      '[data-target="neg-stack"]': 'Combine multiple negative lists.',
+      '[data-target="neg-all-hide"]': 'Show or hide all negative stacks.',
+      '[data-target="neg-order-random"]': 'Randomize order of negative modifiers.',
+      '[data-target="neg-advanced"]': 'Reveal advanced negative options.',
+      '[data-target="lyrics-remove-parens"]': 'Strip parentheses from lyrics before processing.',
+      '[data-target="lyrics-remove-brackets"]': 'Strip brackets from lyrics before processing.',
+      '[data-target="lyrics-insert-random"]': 'Randomize insertion intervals for lyric terms.',
+      // Inputs and lists
+      '#base-select': 'Choose base prompt preset.',
+      '#base-input': 'Comma or newline separated base prompts.',
+      '#base-order-select': 'Preset ordering for base prompts.',
+      '#base-order-input': 'Manual order for base prompts.',
+      'select[id^="pos-select"]': 'Choose positive list preset.',
+      'textarea[id^="pos-input"]': 'Positive modifiers separated by commas or newlines.',
+      'select[id^="pos-order-select"]': 'Preset ordering for positives.',
+      'textarea[id^="pos-order-input"]': 'Manual order for positives.',
+      'select[id^="pos-depth-select"]': 'Depth position options for positives.',
+      'textarea[id^="pos-depth-input"]': 'Manual depth indices for positives.',
+      '#pos-stack-size': 'Number of positive stacks.',
+      'select[id^="neg-select"]': 'Choose negative list preset.',
+      'textarea[id^="neg-input"]': 'Negative modifiers separated by commas or newlines.',
+      'select[id^="neg-order-select"]': 'Preset ordering for negatives.',
+      'textarea[id^="neg-order-input"]': 'Manual order for negatives.',
+      'select[id^="neg-depth-select"]': 'Depth position options for negatives.',
+      'textarea[id^="neg-depth-input"]': 'Manual depth indices for negatives.',
+      '#neg-stack-size': 'Number of negative stacks.',
+      '#divider-select': 'Choose divider preset.',
+      '#divider-input': 'Divider phrases rotated between terms.',
+      '#divider-order-select': 'Preset ordering for dividers.',
+      '#divider-order-input': 'Manual order for dividers.',
+      '#length-select': 'Preset length limits.',
+      '#length-input': 'Maximum allowed characters.',
+      '#lyrics-select': 'Choose lyrics preset.',
+      '#lyrics-input': 'Lyrics text with optional random spacing.',
+      '#lyrics-space': 'Max spaces inserted between lyric words.',
+      '#lyrics-insert-select': 'Choose insertion terms preset.',
+      '#lyrics-insert-input': 'Terms to inject into lyrics.',
+      '#lyrics-insert-interval': 'Interval for lyric insertions.',
+      '#lyrics-insert-stack': 'Number of terms inserted each time.'
     };
+
     // Apply help text to matching elements
-    Object.entries(helpMap).forEach(([sel, text]) => {
-      document.querySelectorAll(sel).forEach(el => {
-        if (!el.dataset.help) el.dataset.help = text;
+    const applyHelpHints = (root = document) => {
+      Object.entries(helpMap).forEach(([sel, text]) => {
+        root.querySelectorAll(sel).forEach(el => {
+          if (!el.dataset.help) el.dataset.help = text;
+        });
+      });
+    };
+    applyHelpHints();
+
+    // Observe DOM changes so newly added inputs also get help text
+    const observer = new MutationObserver(muts => {
+      muts.forEach(m => {
+        m.addedNodes.forEach(node => {
+          if (node.nodeType === 1) applyHelpHints(node);
+        });
       });
     });
+    observer.observe(document.body, { childList: true, subtree: true });
+
     // Specific help for output containers
     const posOut = document.getElementById('positive-output');
     if (posOut) posOut.closest('.input-group').dataset.help = 'Resulting positive prompt.';
@@ -2856,9 +2916,6 @@
     });
     document.querySelectorAll('.hide-button').forEach(el => {
       if (!el.dataset.help) el.dataset.help = 'Hide or show associated inputs.';
-    });
-    document.querySelectorAll('.toggle-button').forEach(el => {
-      if (!el.dataset.help) el.dataset.help = 'Toggle related setting.';
     });
 
     let tooltip; // Reused tooltip element

--- a/src/style.css
+++ b/src/style.css
@@ -587,3 +587,16 @@ button {
 .section-data {
   background: linear-gradient(45deg, rgba(80, 80, 80, 0.3), rgba(40, 40, 40, 0.3));
 }
+
+/* Help mode tooltip styling */
+.help-tooltip {
+  position: absolute;
+  background: #000;
+  color: #fff;
+  border: 1px solid #444;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  max-width: 200px;
+  pointer-events: none;
+  z-index: 2000;
+}


### PR DESCRIPTION
## Summary
- add quick-action toggle to activate help mode
- display `data-help` tooltips for buttons and sections
- style custom tooltip overlay for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99f9b0464832198cf499f537c30cb