### PR TITLE
Wrap button rows to prevent mobile overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Prompt Enhancer is a small web tool for building AI prompts. It combines base prompts with positive and negative modifiers to produce two variations. Everything runs in the browser with no build step.
 
-Open `src/index.html` to use the tool. Enter a list of base phrases, pick modifier presets and press **Generate**. You can save your data to a file or reload it later.
+Open `src/index.html` to use the tool. Enter a list of base phrases, pick modifier presets and press **Generate**. You can save your data to a file or reload it later. On narrow screens, button rows automatically wrap so text labels stay within their section.
 
 The code is intentionally kept in a single `script.js` file so an LLM can search through the entire logic easily. Comments and a small table of contents guide navigation. Following the **50% Rule**, even small clarifications or tests compound into a much more reliable project.
 

--- a/src/style.css
+++ b/src/style.css
@@ -379,14 +379,17 @@ button {
 }
 
 /* Checkbox label styling */
+/* Flex container wraps buttons on narrow screens to prevent overflow */
 .label-row {
-    display: flex;
-    align-items: center;
-    margin-bottom: 0.25rem;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+  flex-wrap: wrap; /* drop controls to new line instead of overshooting */
 }
 
 .label-row label {
-    margin-right: auto; /* push button stack to the right */
+  margin-right: auto; /* push button stack to the right */
+  /* When wrapping occurs, label stays on top while buttons follow */
 }
 
 

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -46,4 +46,18 @@ describe('Button layout', () => {
     expect(posHide.dataset.targets).toContain('pos-depth-input');
     expect(negHide.dataset.targets).toContain('neg-depth-input');
   });
+
+  // Layout adaptation: label rows should wrap so buttons never overflow their container
+  test('label-row flex container wraps buttons onto a new line', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+    const css = fs.readFileSync(path.join(__dirname, '..', 'src', 'style.css'), 'utf8');
+    const dom = new JSDOM(html, { pretendToBeVisual: true });
+    const { window } = dom;
+    const styleEl = window.document.createElement('style');
+    styleEl.textContent = css;
+    window.document.head.appendChild(styleEl); // load stylesheet so computed style reflects flex-wrap
+    const row = window.document.querySelector('.label-row');
+    const computed = window.getComputedStyle(row);
+    expect(computed.flexWrap).toBe('wrap');
+  });
 });


### PR DESCRIPTION
## Summary
- allow `.label-row` to wrap, keeping text buttons inside their sections on narrow screens
- document mobile wrap behavior in the README
- test that `.label-row` uses `flex-wrap: wrap`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac494e9754832180d9a3a77edc58bc