### PR TITLE
fix: stabilize mobile button layout

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -54,6 +54,11 @@ tooltips when users click elements. Lists and input boxes also need coverage;
 avoid vague text. When new buttons or sections are added, provide concise,
 specific descriptions so the help overlay stays informative.
 
+Label rows rely on flexbox. Place any `.button-col` directly after the
+`<label>` so icon controls stay anchored at the top-right of their inputs on
+mobile screens. Text buttons should follow the icon column so they wrap
+underneath while staying right aligned.
+
 ## Testing
 
 Run the full suite with `npm test` whenever you modify code. Expand coverage whenever a bug is fixed or a new feature is added.

--- a/src/index.html
+++ b/src/index.html
@@ -82,6 +82,10 @@
         <div class="input-group section-positive">
           <div class="label-row">
             <label for="pos-input">Positive Modifier List</label>
+            <!-- Icon column placed right after label so it stays top-right on mobile -->
+            <div class="button-col">
+              <input type="checkbox" id="pos-shuffle" hidden>
+            </div>
             <input type="checkbox" id="pos-stack" hidden>
             <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
             <input type="checkbox" id="pos-all-hide" hidden>
@@ -90,9 +94,6 @@
             <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
             <input type="checkbox" id="pos-advanced" hidden>
             <button type="button" class="toggle-button" data-target="pos-advanced" data-on="Advanced" data-off="Simple">Simple</button>
-            <div class="button-col">
-              <input type="checkbox" id="pos-shuffle" hidden>
-            </div>
           </div>
           <select id="pos-stack-size" style="display:none">
             <option value="2">2</option>
@@ -142,6 +143,10 @@
         <div class="input-group section-negative">
           <div class="label-row">
             <label for="neg-input">Negative Modifier List</label>
+            <!-- Icon column placed right after label so it stays top-right on mobile -->
+            <div class="button-col">
+              <input type="checkbox" id="neg-shuffle" hidden>
+            </div>
             <input type="checkbox" id="neg-include-pos" hidden>
             <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
             <input type="checkbox" id="neg-stack" hidden>
@@ -152,9 +157,6 @@
             <button type="button" class="toggle-button" data-target="neg-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
             <input type="checkbox" id="neg-advanced" hidden>
             <button type="button" class="toggle-button" data-target="neg-advanced" data-on="Advanced" data-off="Simple">Simple</button>
-            <div class="button-col">
-              <input type="checkbox" id="neg-shuffle" hidden>
-            </div>
           </div>
           <select id="neg-stack-size" style="display:none">
             <option value="2">2</option>

--- a/src/style.css
+++ b/src/style.css
@@ -385,11 +385,12 @@ button {
   align-items: center;
   margin-bottom: 0.25rem;
   flex-wrap: wrap; /* drop controls to new line instead of overshooting */
+  justify-content: flex-end; /* keep wrapped controls aligned right */
+  gap: 0.25rem; /* uniform spacing for multi-row layouts */
 }
 
 .label-row label {
-  margin-right: auto; /* push button stack to the right */
-  /* When wrapping occurs, label stays on top while buttons follow */
+  flex: 1 0 100%; /* label occupies its own row on top */
 }
 
 


### PR DESCRIPTION
## Summary
- keep label rows' wrapped controls aligned to the right
- place icon button columns immediately after labels so they stay anchored on mobile
- document label-row ordering in AGENTS notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae266455f08321b2e0063d41e7fe9c