### PR TITLE
Fix mobile button alignment on small screens

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -35,25 +35,31 @@
           <div class="input-group section-data">
             <div class="label-row">
               <label>Data</label>
-              <input type="file" id="data-file" accept="application/json" style="display:none">
-              <button type="button" id="load-data">Load</button>
-              <button type="button" id="save-data">Save</button>
-              <button type="button" id="reset-data">Reset</button>
+              <!-- Button group ensures right alignment on wrap -->
+              <div class="button-col">
+                <input type="file" id="data-file" accept="application/json" style="display:none">
+                <button type="button" id="load-data">Load</button>
+                <button type="button" id="save-data">Save</button>
+                <button type="button" id="reset-data">Reset</button>
+              </div>
             </div>
           </div>
         <!-- Hide all toggle -->
         <div class="input-group section-actions">
           <div class="label-row">
             <label>Quick Actions</label>
-            <input type="checkbox" id="all-hide" hidden>
-            <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
-            <input type="checkbox" id="all-random" hidden>
-            <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="advanced-mode" hidden>
-            <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
-            <!-- Help mode toggles tooltip explanations for UI elements -->
-            <input type="checkbox" id="help-mode" hidden>
-            <button type="button" class="toggle-button" data-target="help-mode" data-on="Help On" data-off="Help Off">Help Off</button>
+            <!-- Wrap toggles so they align to the right on mobile -->
+            <div class="button-col">
+              <input type="checkbox" id="all-hide" hidden>
+              <button type="button" class="toggle-button" data-target="all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+              <input type="checkbox" id="all-random" hidden>
+              <button type="button" class="toggle-button" data-target="all-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+              <input type="checkbox" id="advanced-mode" hidden>
+              <button type="button" class="toggle-button" data-target="advanced-mode" data-on="Advanced" data-off="Simple">Simple</button>
+              <!-- Help mode toggles tooltip explanations for UI elements -->
+              <input type="checkbox" id="help-mode" hidden>
+              <button type="button" class="toggle-button" data-target="help-mode" data-on="Help On" data-off="Help Off">Help Off</button>
+            </div>
           </div>
         </div>
         <!-- Base prompt input section -->
@@ -82,15 +88,16 @@
         <div class="input-group section-positive">
           <div class="label-row">
             <label for="pos-input">Positive Modifier List</label>
-            <input type="checkbox" id="pos-stack" hidden>
-            <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
-            <input type="checkbox" id="pos-all-hide" hidden>
-            <button type="button" class="toggle-button" data-target="pos-all-hide" data-on="All hidden" data-off="All visible">All visible</button>
-            <input type="checkbox" id="pos-order-random" hidden>
-            <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="pos-advanced" hidden>
-            <button type="button" class="toggle-button" data-target="pos-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+            <!-- Group toggles and shuffle icon for consistent layout -->
             <div class="button-col">
+              <input type="checkbox" id="pos-stack" hidden>
+              <button type="button" class="toggle-button" data-target="pos-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
+              <input type="checkbox" id="pos-all-hide" hidden>
+              <button type="button" class="toggle-button" data-target="pos-all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+              <input type="checkbox" id="pos-order-random" hidden>
+              <button type="button" class="toggle-button" data-target="pos-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+              <input type="checkbox" id="pos-advanced" hidden>
+              <button type="button" class="toggle-button" data-target="pos-advanced" data-on="Advanced" data-off="Simple">Simple</button>
               <input type="checkbox" id="pos-shuffle" hidden>
             </div>
           </div>
@@ -142,17 +149,18 @@
         <div class="input-group section-negative">
           <div class="label-row">
             <label for="neg-input">Negative Modifier List</label>
-            <input type="checkbox" id="neg-include-pos" hidden>
-            <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
-            <input type="checkbox" id="neg-stack" hidden>
-            <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
-            <input type="checkbox" id="neg-all-hide" hidden>
-            <button type="button" class="toggle-button" data-target="neg-all-hide" data-on="All hidden" data-off="All visible">All visible</button>
-            <input type="checkbox" id="neg-order-random" hidden>
-            <button type="button" class="toggle-button" data-target="neg-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
-            <input type="checkbox" id="neg-advanced" hidden>
-            <button type="button" class="toggle-button" data-target="neg-advanced" data-on="Advanced" data-off="Simple">Simple</button>
+            <!-- Match positive section grouping for mobile -->
             <div class="button-col">
+              <input type="checkbox" id="neg-include-pos" hidden>
+              <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
+              <input type="checkbox" id="neg-stack" hidden>
+              <button type="button" class="toggle-button" data-target="neg-stack" data-on="Stack On" data-off="Stack Off">Stack Off</button>
+              <input type="checkbox" id="neg-all-hide" hidden>
+              <button type="button" class="toggle-button" data-target="neg-all-hide" data-on="All hidden" data-off="All visible">All visible</button>
+              <input type="checkbox" id="neg-order-random" hidden>
+              <button type="button" class="toggle-button" data-target="neg-order-random" data-on="Randomized" data-off="Canonical">Canonical</button>
+              <input type="checkbox" id="neg-advanced" hidden>
+              <button type="button" class="toggle-button" data-target="neg-advanced" data-on="Advanced" data-off="Simple">Simple</button>
               <input type="checkbox" id="neg-shuffle" hidden>
             </div>
           </div>
@@ -248,11 +256,12 @@
           <div class="stack-block section-lyrics" id="lyrics-block">
             <div class="label-row">
               <label for="lyrics-input">Lyrics</label>
-              <input type="checkbox" id="lyrics-remove-parens" hidden>
-              <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
-              <input type="checkbox" id="lyrics-remove-brackets" hidden>
-              <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
+              <!-- Keep cleaning toggles and icons aligned -->
               <div class="button-col">
+                <input type="checkbox" id="lyrics-remove-parens" hidden>
+                <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
+                <input type="checkbox" id="lyrics-remove-brackets" hidden>
+                <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
                 <button type="button" id="lyrics-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
@@ -295,8 +304,11 @@
             </div>
             <div class="label-row">
               <label for="lyrics-insert-interval">Insert Every</label>
-              <input type="checkbox" id="lyrics-insert-random" hidden>
-              <button type="button" class="toggle-button" data-target="lyrics-insert-random" data-on="Randomized" data-off="Fixed">Fixed</button>
+              <!-- Randomization toggle shares group styling -->
+              <div class="button-col">
+                <input type="checkbox" id="lyrics-insert-random" hidden>
+                <button type="button" class="toggle-button" data-target="lyrics-insert-random" data-on="Randomized" data-off="Fixed">Fixed</button>
+              </div>
             </div>
             <select id="lyrics-insert-interval">
               <option value="0" selected>0</option>

--- a/src/style.css
+++ b/src/style.css
@@ -300,6 +300,12 @@ blockquote p {
         margin-bottom: 0.5rem;
         margin-right: 0;
     }
+    .label-row label {
+        flex-basis: 100%; /* stack label above buttons on narrow screens */
+    }
+    .label-row .button-col {
+        width: 100%; /* ensure button groups span full width */
+    }
 }
 
 /* ===== FORM ELEMENTS ===== */
@@ -385,6 +391,7 @@ button {
   align-items: center;
   margin-bottom: 0.25rem;
   flex-wrap: wrap; /* drop controls to new line instead of overshooting */
+  gap: 0.25rem; /* consistent spacing for wrapped controls */
 }
 
 .label-row label {
@@ -447,10 +454,13 @@ button {
 }
 
 .button-col {
-  display: inline-flex;
+  display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: 0.25rem;
+  margin-left: auto; /* keep button groups flush right */
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.25rem; /* space between buttons */
 }
 .button-col .icon-button {
   width: 1.8rem;
@@ -459,11 +469,6 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
-  margin-left: 0;
-  margin-right: 0.25rem;
-}
-.button-col .icon-button:last-child {
-  margin-right: 0;
 }
 
 .toggle-button.icon-button {


### PR DESCRIPTION
## Summary
- group button controls inside label rows so they stay flush right when wrapping
- add flex and media-query rules to keep button stacks aligned on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae266455f08321b2e0063d41e7fe9c