### PR TITLE
style: center headers on mobile

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -26,6 +26,12 @@ Directives for LLMs:
 
 Indentation is two spaces with no trailing whitespace.
 
+### Button Grouping
+
+Text-based toggles that appear alongside icon buttons should sit in a
+separate `.text-button-group` container. This keeps icons clustered for
+the right edge on mobile while text buttons center on their own line.
+
 ### Depth Control Note
 
 Depth inputs rely on DOM watchers to rebuild values when related fields change.

--- a/src/index.html
+++ b/src/index.html
@@ -256,12 +256,15 @@
           <div class="stack-block section-lyrics" id="lyrics-block">
             <div class="label-row">
               <label for="lyrics-input">Lyrics</label>
-              <!-- Keep cleaning toggles and icons aligned -->
-              <div class="button-col">
+              <!-- Cleaning toggles live in their own group so icons don't overflow on mobile -->
+              <div class="button-col text-button-group">
                 <input type="checkbox" id="lyrics-remove-parens" hidden>
                 <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
                 <input type="checkbox" id="lyrics-remove-brackets" hidden>
                 <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
+              </div>
+              <!-- Icon buttons remain clustered separately to avoid wrapping with text toggles -->
+              <div class="button-col">
                 <button type="button" id="lyrics-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>

--- a/src/style.css
+++ b/src/style.css
@@ -473,6 +473,8 @@ button {
   flex: 1;
 }
 
+/* Shared layout for button clusters.
+ * Text groups sit before icons while icons still hug the edge. */
 .button-col {
   display: flex;
   flex-direction: row;
@@ -480,6 +482,10 @@ button {
   margin-left: auto; /* keep button groups flush right */
   flex-wrap: wrap;
   justify-content: flex-start; /* text buttons lead, icons float right */
+}
+.button-col.text-button-group {
+  margin-left: 0; /* keep text toggles adjacent so icon group can sit separately */
+  justify-content: flex-start; /* let toggles flow naturally on wide screens */
 }
 .button-col .icon-button {
   width: 1.8rem;

--- a/src/style.css
+++ b/src/style.css
@@ -284,7 +284,7 @@ blockquote p {
 /* Mobile breakpoint
  * - Trim padding for compact layout
  * - Center headers and section titles
- * - Span button groups full width on wrap
+ * - Keep icon button groups distinct from text controls
  */
 @media (max-width: 480px) {
   .main-content {
@@ -301,7 +301,7 @@ blockquote p {
 
   button {
     width: auto; /* keep buttons at their natural size */
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem; /* tighten vertical spacing */
     margin-right: 0;
   }
 
@@ -316,9 +316,7 @@ blockquote p {
     text-align: center; /* ensure label text is centered */
   }
 
-  .label-row .button-col {
-    width: 100%; /* ensure button groups span full width */
-  }
+  /* allow button stacks to size naturally so icon groups stay intact */
 }
 
 /* ===== FORM ELEMENTS ===== */
@@ -404,7 +402,6 @@ button {
   align-items: center;
   margin-bottom: 0.25rem;
   flex-wrap: wrap; /* drop controls to new line instead of overshooting */
-  gap: 0.25rem; /* consistent spacing for wrapped controls */
 }
 
 .label-row label {
@@ -472,8 +469,7 @@ button {
   align-items: center;
   margin-left: auto; /* keep button groups flush right */
   flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.25rem; /* space between buttons */
+  justify-content: flex-start; /* text buttons lead, icons float right */
 }
 .button-col .icon-button {
   width: 1.8rem;
@@ -482,6 +478,10 @@ button {
   justify-content: center;
   align-items: center;
   padding: 0;
+}
+/* first icon pushes remaining icons as a unit to the edge */
+.button-col .icon-button:first-of-type {
+  margin-left: auto;
 }
 
 .toggle-button.icon-button {

--- a/src/style.css
+++ b/src/style.css
@@ -283,8 +283,8 @@ blockquote p {
 
 /* Mobile breakpoint
  * - Trim padding for compact layout
- * - Center headers and section titles
- * - Keep icon button groups distinct from text controls
+ * - Center headers and text button rows
+ * - Keep icon clusters pinned to the right
  */
 @media (max-width: 480px) {
   .main-content {
@@ -314,6 +314,16 @@ blockquote p {
     flex-basis: 100%; /* stack label above buttons on narrow screens */
     margin: 0 auto; /* center label when it spans full width */
     text-align: center; /* ensure label text is centered */
+  }
+
+  /* Center text-based controls but keep icon clusters pinned right */
+  .label-row .button-col {
+    width: 100%;
+    margin-left: 0; /* drop desktop right alignment */
+    justify-content: center; /* default to middle for text buttons */
+  }
+  .label-row .button-col .icon-button:first-of-type {
+    margin-left: auto; /* first icon nudges its group to the edge */
   }
 
   /* allow button stacks to size naturally so icon groups stay intact */

--- a/src/style.css
+++ b/src/style.css
@@ -281,31 +281,44 @@ blockquote p {
     }
 }
 
-/* Mobile breakpoint */
+/* Mobile breakpoint
+ * - Trim padding for compact layout
+ * - Center headers and section titles
+ * - Span button groups full width on wrap
+ */
 @media (max-width: 480px) {
-    .main-content {
-        padding: 10px;
-    }
+  .main-content {
+    padding: 10px;
+  }
 
-    .content {
-        padding: 10px;
-    }
+  .content {
+    padding: 10px;
+  }
 
-    .input-group {
-        margin-bottom: 0.75rem;
-    }
+  .input-group {
+    margin-bottom: 0.75rem;
+  }
 
-    button {
-        width: auto; /* keep buttons at their natural size */
-        margin-bottom: 0.5rem;
-        margin-right: 0;
-    }
-    .label-row label {
-        flex-basis: 100%; /* stack label above buttons on narrow screens */
-    }
-    .label-row .button-col {
-        width: 100%; /* ensure button groups span full width */
-    }
+  button {
+    width: auto; /* keep buttons at their natural size */
+    margin-bottom: 0.5rem;
+    margin-right: 0;
+  }
+
+  h1,
+  .output h2 {
+    text-align: center; /* center main heading and output titles */
+  }
+
+  .label-row label {
+    flex-basis: 100%; /* stack label above buttons on narrow screens */
+    margin: 0 auto; /* center label when it spans full width */
+    text-align: center; /* ensure label text is centered */
+  }
+
+  .label-row .button-col {
+    width: 100%; /* ensure button groups span full width */
+  }
 }
 
 /* ===== FORM ELEMENTS ===== */


### PR DESCRIPTION
## Summary
- center main heading and section labels for small screens
- document mobile centering in stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae39fa10dc8321b10f54ee2a24521a