### PR TITLE
style: improve mobile header and lyric layout

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -256,12 +256,14 @@
           <div class="stack-block section-lyrics" id="lyrics-block">
             <div class="label-row">
               <label for="lyrics-input">Lyrics</label>
-              <!-- Keep cleaning toggles and icons aligned -->
-              <div class="button-col">
+              <!-- Center cleaning toggles separately from icon cluster -->
+              <div class="text-buttons">
                 <input type="checkbox" id="lyrics-remove-parens" hidden>
                 <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
                 <input type="checkbox" id="lyrics-remove-brackets" hidden>
                 <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
+              </div>
+              <div class="button-col icon-buttons">
                 <button type="button" id="lyrics-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>

--- a/src/style.css
+++ b/src/style.css
@@ -281,31 +281,58 @@ blockquote p {
     }
 }
 
-/* Mobile breakpoint */
+/* Mobile breakpoint
+ * - Trim padding for compact layout
+ * - Center headers and text button rows
+ * - Keep icon clusters pinned to the right
+ */
 @media (max-width: 480px) {
-    .main-content {
-        padding: 10px;
-    }
+  .main-content {
+    padding: 10px;
+  }
 
-    .content {
-        padding: 10px;
-    }
+  .content {
+    padding: 10px;
+  }
 
-    .input-group {
-        margin-bottom: 0.75rem;
-    }
+  .input-group {
+    margin-bottom: 0.75rem;
+  }
 
-    button {
-        width: auto; /* keep buttons at their natural size */
-        margin-bottom: 0.5rem;
-        margin-right: 0;
-    }
-    .label-row label {
-        flex-basis: 100%; /* stack label above buttons on narrow screens */
-    }
-    .label-row .button-col {
-        width: 100%; /* ensure button groups span full width */
-    }
+  button {
+    width: auto; /* keep buttons at their natural size */
+    margin-bottom: 0.25rem; /* tighten vertical spacing */
+    margin-right: 0;
+  }
+
+  h1,
+  .output h2 {
+    text-align: center; /* center main heading and output titles */
+  }
+
+  .label-row label {
+    flex-basis: 100%; /* stack label above buttons on narrow screens */
+    margin: 0 auto; /* center label when it spans full width */
+    text-align: center; /* ensure label text is centered */
+  }
+
+  /* Center text-based controls while keeping icon clusters pinned right */
+  .label-row .button-col {
+    width: 100%;
+    margin-left: 0; /* drop desktop right alignment */
+    justify-content: center; /* default alignment for text groups */
+  }
+  .label-row .icon-buttons {
+    width: 100%;
+    margin-left: 0;
+    justify-content: flex-end;
+  }
+  .label-row .text-buttons {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* allow button stacks to size naturally so icon groups stay intact */
 }
 
 /* ===== FORM ELEMENTS ===== */
@@ -391,7 +418,6 @@ button {
   align-items: center;
   margin-bottom: 0.25rem;
   flex-wrap: wrap; /* drop controls to new line instead of overshooting */
-  gap: 0.25rem; /* consistent spacing for wrapped controls */
 }
 
 .label-row label {
@@ -457,10 +483,15 @@ button {
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: auto; /* keep button groups flush right */
+  margin-left: auto; /* keep icon clusters flush right */
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 0.25rem; /* space between buttons */
+}
+.text-buttons {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 .button-col .icon-button {
   width: 1.8rem;


### PR DESCRIPTION
## Summary
- center main heading and section labels for small screens
- keep lyric icon buttons grouped on mobile
- tighten spacing between buttons for a cleaner look
- center text button groups while keeping icon clusters right-aligned
- split lyric cleaning toggles into their own row so icons no longer overflow on narrow screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae39fa10dc8321b10f54ee2a24521a