### PR TITLE
Center lyrics text buttons

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -256,19 +256,19 @@
           <div class="stack-block section-lyrics" id="lyrics-block">
             <div class="label-row">
               <label for="lyrics-input">Lyrics</label>
-              <!-- Cleaning toggles live in their own group so icons don't overflow on mobile -->
-              <div class="button-col text-button-group">
-                <input type="checkbox" id="lyrics-remove-parens" hidden>
-                <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
-                <input type="checkbox" id="lyrics-remove-brackets" hidden>
-                <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
-              </div>
-              <!-- Icon buttons remain clustered separately to avoid wrapping with text toggles -->
+              <!-- Icon buttons remain clustered to the right on all screens -->
               <div class="button-col">
                 <button type="button" id="lyrics-save" class="save-button icon-button" title="Save">&#128190;</button>
                 <button type="button" class="copy-button icon-button" data-target="lyrics-input" title="Copy">&#128203;</button>
                 <input type="checkbox" id="lyrics-hide" data-targets="lyrics-input,lyrics-space,lyrics-remove-parens,lyrics-remove-brackets" hidden>
                 <button type="button" class="toggle-button icon-button hide-button" data-target="lyrics-hide" data-on="☰" data-off="✖">☰</button>
+              </div>
+              <!-- Cleaning toggles break to their own centered row -->
+              <div class="button-col text-button-group">
+                <input type="checkbox" id="lyrics-remove-parens" hidden>
+                <button type="button" class="toggle-button" data-target="lyrics-remove-parens" data-on="Parens Removed" data-off="Parens Kept">Parens Kept</button>
+                <input type="checkbox" id="lyrics-remove-brackets" hidden>
+                <button type="button" class="toggle-button" data-target="lyrics-remove-brackets" data-on="Brackets Removed" data-off="Brackets Kept">Brackets Kept</button>
               </div>
             </div>
             <select id="lyrics-select"></select>
@@ -307,8 +307,8 @@
             </div>
             <div class="label-row">
               <label for="lyrics-insert-interval">Insert Every</label>
-              <!-- Randomization toggle shares group styling -->
-              <div class="button-col">
+              <!-- Randomization toggle centers on its own line -->
+              <div class="button-col text-button-group">
                 <input type="checkbox" id="lyrics-insert-random" hidden>
                 <button type="button" class="toggle-button" data-target="lyrics-insert-random" data-on="Randomized" data-off="Fixed">Fixed</button>
               </div>

--- a/src/style.css
+++ b/src/style.css
@@ -484,8 +484,10 @@ button {
   justify-content: flex-start; /* text buttons lead, icons float right */
 }
 .button-col.text-button-group {
-  margin-left: 0; /* keep text toggles adjacent so icon group can sit separately */
-  justify-content: flex-start; /* let toggles flow naturally on wide screens */
+  /* text-only groups span the full row so their toggles center */
+  margin-left: 0; /* prevent text buttons from hugging the icon cluster */
+  flex-basis: 100%; /* force a line break away from labels and icons */
+  justify-content: center; /* center text buttons on their own row */
 }
 .button-col .icon-button {
   width: 1.8rem;


### PR DESCRIPTION
## Summary
- Center lyrics cleaning toggles on their own line and group icon buttons separately.
- Ensure lyrics insertion randomize toggle uses text-button-group for consistent centering.
- Style text-button groups to span full width and center their contents without affecting icon clusters.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5378fbc08321a6b233336be485f9