### PR TITLE
Center lyrics text toggles on mobile

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -485,7 +485,14 @@ button {
 }
 .button-col.text-button-group {
   margin-left: 0; /* keep text toggles adjacent so icon group can sit separately */
-  justify-content: flex-start; /* let toggles flow naturally on wide screens */
+  justify-content: flex-start; /* let toggles flow naturally on wide screens; mobile override centers */
+}
+
+/* On narrow screens, center text-only groups without affecting icon clusters */
+@media (max-width: 480px) {
+  .button-col.text-button-group {
+    justify-content: center; /* align lyrics toggles with other centered buttons */
+  }
 }
 .button-col .icon-button {
   width: 1.8rem;


### PR DESCRIPTION
## Summary
- Center lyrics text buttons on small screens while keeping icon buttons right-aligned.
- Document responsive text-button behavior in CSS.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5378fbc08321a6b233336be485f9