### PR TITLE
feat: merge lists with conflict resolution

### DIFF
--- a/tests/storageManager.test.js
+++ b/tests/storageManager.test.js
@@ -64,6 +64,31 @@ describe('Storage manager', () => {
     );
   });
 
+  test('importData merges lists by default', () => {
+    const json = {
+      lists: {
+        presets: [
+          { id: 'b', title: 'b', type: 'base', items: ['z'] },
+          { id: 'c', title: 'c', type: 'base', items: ['y'] }
+        ]
+      },
+      state: {}
+    };
+    storage.importData(json);
+    const data = JSON.parse(lists.exportLists());
+    const original = data.presets.find(
+      p => p.title === 'b' && p.type === 'base'
+    );
+    const renamed = data.presets.find(
+      p => p.title === 'b (1)' && p.type === 'base'
+    );
+    expect(original.items).toEqual(['x']);
+    expect(renamed.items).toEqual(['z']);
+    expect(
+      data.presets.some(p => p.title === 'c' && p.type === 'base')
+    ).toBe(true);
+  });
+
   test('loadPersisted prefers localStorage data', () => {
     const saved = {
       lists: { presets: [{ id: 'b', title: 'b', type: 'base', items: ['y'] }] },


### PR DESCRIPTION
## Summary
- add helpers to compare list items and generate unique names
- merge imported lists by default in storage manager
- skip duplicate lists and rename conflicting ones when merging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5476ad4dc8321b903ca37e7255a97