### PR TITLE
feat: add divider stripping option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -214,15 +214,20 @@
         <div class="input-group section-divider">
           <div class="label-row">
             <label for="divider-input">Divider List</label>
-              <div class="button-col">
-                <input type="checkbox" id="divider-shuffle" hidden>
-                <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
-                <button type="button" id="divider-delete" class="delete-button icon-button" title="Delete" data-help="Remove divider list from presets.">&#128465;&#65039;</button>
-                <button type="button" id="divider-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
-                <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
-                <input type="checkbox" id="divider-hide" data-targets="divider-input,divider-order-input" hidden>
-                <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
-              </div>
+            <!-- Stripping toggle lives in its own group so icon buttons stay aligned -->
+            <div class="button-col text-button-group">
+              <input type="checkbox" id="divider-strip" hidden>
+              <button type="button" class="toggle-button" data-target="divider-strip" data-on="Strip existing" data-off="Don't strip">Don't strip</button>
+            </div>
+            <div class="button-col">
+              <input type="checkbox" id="divider-shuffle" hidden>
+              <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>
+              <button type="button" id="divider-delete" class="delete-button icon-button" title="Delete" data-help="Remove divider list from presets.">&#128465;&#65039;</button>
+              <button type="button" id="divider-reroll" class="toggle-button icon-button random-button" title="Reroll">&#127922;</button>
+              <button type="button" class="copy-button icon-button" data-target="divider-input" title="Copy">&#128203;</button>
+              <input type="checkbox" id="divider-hide" data-targets="divider-input,divider-order-input" hidden>
+              <button type="button" class="toggle-button icon-button hide-button" data-target="divider-hide" data-on="☰" data-off="✖">☰</button>
+            </div>
           </div>
           <select id="divider-select"></select>
           <div class="input-row">

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -23,6 +23,7 @@ const {
   parseDividerInput,
   parseOrderInput,
   applyOrder,
+  stripExistingDividers,
   insertAtDepth,
   countWords,
   computeDepthCounts
@@ -50,6 +51,8 @@ const {
   depthWatchIds,
   setupPresetListener
 } = ui;
+
+const { collectInputs } = ui;
 
 describe('Utility functions', () => {
   test('parseInput splits and trims correctly', () => {
@@ -116,9 +119,42 @@ describe('Utility functions', () => {
     expect(parseOrderInput('1, 2 3')).toEqual([1, 2, 3]);
   });
 
+  test('stripExistingDividers removes dividers and punctuation', () => {
+    const items = ['cat and dog.', 'and', ', ,', 'bird . .'];
+    const divs = ['and'];
+    expect(stripExistingDividers(items, divs)).toEqual(['cat dog.', 'bird']);
+  });
+
   test('applyOrder reorders list cycling values', () => {
     const out = applyOrder(['a', 'b', 'c'], [2, 0]);
     expect(out).toEqual(['c', 'a', 'c']);
+  });
+
+  test('collectInputs strips dividers when enabled', () => {
+    document.body.innerHTML = `
+      <textarea id="base-input">cat, and, dog</textarea>
+      <input type="checkbox" id="pos-stack">
+      <input type="number" id="pos-stack-size" value="1">
+      <input type="checkbox" id="neg-stack">
+      <input type="number" id="neg-stack-size" value="1">
+      <textarea id="pos-input">red, and, blue</textarea>
+      <textarea id="neg-input"></textarea>
+      <input type="checkbox" id="neg-include-pos">
+      <textarea id="divider-input">and</textarea>
+      <input type="checkbox" id="divider-strip" checked>
+      <input type="checkbox" id="divider-shuffle">
+      <select id="length-select"><option value="custom">c</option></select>
+      <input id="length-input" value="100">
+      <textarea id="pos-depth-input"></textarea>
+      <textarea id="neg-depth-input"></textarea>
+      <textarea id="base-order-input"></textarea>
+      <textarea id="pos-order-input"></textarea>
+      <textarea id="neg-order-input"></textarea>
+      <textarea id="divider-order-input"></textarea>
+    `;
+    const { baseItems, posMods } = collectInputs();
+    expect(baseItems).toEqual(['cat,', 'dog.']);
+    expect(posMods).toEqual(['red', 'blue']);
   });
 
   test('insertAtDepth inserts term at depth', () => {


### PR DESCRIPTION
## Summary
- add divider section toggle to strip existing connectors
- preprocess prompt lists with `stripExistingDividers`
- cover divider stripping with unit and integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54e73cb4c83218624a3b84a68d591