### PR TITLE
feat: add divider stripping option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -214,6 +214,10 @@
         <div class="input-group section-divider">
           <div class="label-row">
             <label for="divider-input">Divider List</label>
+              <div class="button-col text-button-group">
+                <input type="checkbox" id="divider-strip" hidden>
+                <button type="button" class="toggle-button" data-target="divider-strip" data-on="Strip Existing" data-off="Don't Strip">Don't Strip</button>
+              </div>
               <div class="button-col">
                 <input type="checkbox" id="divider-shuffle" hidden>
                 <button type="button" id="divider-save" class="save-button icon-button" title="Save">&#128190;</button>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -336,6 +336,30 @@ describe('Prompt building', () => {
     expect(out.positive.startsWith('a, b')).toBe(true);
   });
 
+  test('buildVersions strips existing dividers and punctuation when requested', () => {
+    const base = ['foo, ', 'and, , ', 'bar. '];
+    const pos = ['good', 'and'];
+    const out = buildVersions(
+      base,
+      [],
+      pos,
+      20,
+      false,
+      ['and'],
+      true,
+      1,
+      1,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      true
+    );
+    expect(out).toEqual({ positive: 'good foo, good bar. ', negative: 'foo, bar. ' });
+  });
+
   test('buildVersions supports modifier stacking', () => {
     const orig = Math.random;
     Math.random = jest.fn().mockReturnValue(0.999999);


### PR DESCRIPTION
## Summary
- add Strip Existing toggle to divider section to remove divider phrases already present in lists
- preprocess lists before mixing to drop orphaned punctuation
- cover divider stripping with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54e73cb4c83218624a3b84a68d591