### PR TITLE
Add addendum method toggle for negative modifiers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -153,6 +153,8 @@
             <label for="neg-input">Negative Modifier List</label>
             <!-- Match positive section grouping for mobile -->
             <div class="button-col">
+              <input type="checkbox" id="neg-addendum" hidden>
+              <button type="button" class="toggle-button" data-target="neg-addendum" data-on="Addendum Method" data-off="Insertion Method">Insertion Method</button>
               <input type="checkbox" id="neg-include-pos" hidden>
               <button type="button" class="toggle-button" data-target="neg-include-pos" data-on="Positive Mods Included" data-off="Positive Mods Ignored">Positive Mods Ignored</button>
               <input type="checkbox" id="neg-stack" hidden>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -132,9 +132,56 @@ describe('Prompt building', () => {
     expect(out).toEqual({ positive: 'good cat, good cat', negative: 'bad cat, bad cat' });
   });
 
+  test('buildVersions addendum method appends negatives after positives', () => {
+    const out = buildVersions(
+      ['cat'],
+      ['bad'],
+      ['good'],
+      20,
+      false,
+      [],
+      true,
+      1,
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+    expect(out).toEqual({
+      positive: 'good cat, good cat',
+      negative: 'good cat, good cat, bad, bad'
+    });
+  });
+
   test('buildVersions can include positive terms for negatives', () => {
     const out = buildVersions(['cat'], ['bad'], ['good'], 20, true);
     expect(out).toEqual({ positive: 'good cat', negative: 'bad good cat' });
+  });
+
+  test('buildVersions addendum respects include-positive flag', () => {
+    const out = buildVersions(
+      ['cat'],
+      ['bad'],
+      ['good'],
+      20,
+      true,
+      [],
+      true,
+      1,
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+    expect(out).toEqual({ positive: 'good cat', negative: 'good cat, bad' });
   });
 
   test('buildVersions applies negative depth after positives', () => {


### PR DESCRIPTION
## Summary
- add a toggle that switches negatives between insertion and addendum modes
- capture inserted negative modifiers so addendum output appends them after the positive prompt while reusing existing trimming
- extend unit tests to cover the addendum behaviour and include-positive interaction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf94a077488321ae515711ceafbef2