### PR TITLE
Fix double application of base order during stacking

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -488,6 +488,26 @@ describe('Prompt building', () => {
     expect(out.negative).toBe(expectedNeg);
   });
 
+  test('buildVersions applies base order exactly once', () => {
+    const base = ['alpha', 'beta', 'gamma'];
+    const out = buildVersions(
+      base,
+      ['neg'],
+      ['pos'],
+      80,
+      false,
+      [],
+      true,
+      1,
+      1,
+      null,
+      null,
+      [2, 0, 1]
+    );
+    const firstCycle = out.positive.split(', ').slice(0, base.length);
+    expect(firstCycle).toEqual(['pos gamma', 'pos alpha', 'pos beta']);
+  });
+
   // Complex multi-stack scenario combining Unicode and nested punctuation
   test('buildVersions handles unicode and parentheses in multi-stack prompts', () => {
     const items = parseInput('First (one.) Second.', true);


### PR DESCRIPTION
## Summary
- add a regression test that demonstrates base order permutations should apply only once
- update `buildVersions` to reuse the already-ordered base items so randomization stays uniform across stacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e214547d608321bad32739936add48