### PR TITLE
Add configurable list delimiters

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,17 @@
             </div>
           </div>
         </div>
+        <div class="input-group section-delimiter">
+          <div class="label-row">
+            <label for="list-delimiter-char">List Delimiter</label>
+          </div>
+          <div class="input-row">
+            <input id="list-delimiter-char" maxlength="1" value=" " placeholder="Enter a single character (default: space)">
+          </div>
+          <div class="input-row">
+            <input id="list-delimiter-count" type="number" min="1" value="1" placeholder="Delimiter occurrences per item">
+          </div>
+        </div>
         <!-- Base prompt input section -->
         <div class="input-group section-base">
           <div class="label-row">
@@ -78,7 +89,7 @@
           </div>
           <select id="base-select"></select>
           <div class="input-row">
-            <textarea id="base-input" rows="4" placeholder="Enter comma, semicolon, or newline separated items"></textarea>
+            <textarea id="base-input" rows="4" placeholder="Enter items separated by the chosen delimiter or newlines"></textarea>
           </div>
           <select id="base-order-select"></select>
           <div class="input-row">

--- a/tests/dynamicDom.test.js
+++ b/tests/dynamicDom.test.js
@@ -7,6 +7,10 @@ const main = require('../src/script');
 const ui = main;
 
 describe('Dynamic DOM updates', () => {
+  beforeEach(() => {
+    ui.updateListSplitSettings(',', 1);
+  });
+
   test('updateDepthContainers refreshes watchers without duplicating controls', () => {
     document.body.innerHTML = `
       <textarea id="base-input">foo</textarea>

--- a/tests/stateManager.test.js
+++ b/tests/stateManager.test.js
@@ -15,6 +15,8 @@ function setupDOM() {
     <input type="checkbox" id="base-shuffle">
     <select id="base-order-select"></select>
     <textarea id="base-order-input"></textarea>
+    <input id="list-delimiter-char" value=" ">
+    <input id="list-delimiter-count" value="1" type="number">
     <select id="pos-select"></select>
     <textarea id="pos-input"></textarea>
     <input type="checkbox" id="pos-shuffle">
@@ -106,6 +108,18 @@ describe('State manager integration', () => {
     state.importState(JSON.parse(json));
     expect(document.getElementById('pos-depth-input').value).toBe('1,2');
     expect(document.getElementById('neg-depth-input').value).toBe('3');
+  });
+
+  test('delimiter settings persist through export and import', () => {
+    document.getElementById('list-delimiter-char').value = '-';
+    document.getElementById('list-delimiter-count').value = '2';
+    state.loadFromDOM();
+    const json = state.exportState();
+    document.getElementById('list-delimiter-char').value = ' ';
+    document.getElementById('list-delimiter-count').value = '1';
+    state.importState(JSON.parse(json));
+    expect(document.getElementById('list-delimiter-char').value).toBe('-');
+    expect(document.getElementById('list-delimiter-count').value).toBe('2');
   });
 
   test('stacked inputs round trip through state export', () => {


### PR DESCRIPTION
## Summary
- add a global list delimiter control with configurable character and grouping count and wire it into parsing and help text
- ensure delimiter settings are initialized and validated through the UI while keeping new defaults in list parsing
- expand automated coverage for delimiter behavior and persistence across UI and state exports

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b25fd4fb08321a956b00548bc0fd3)